### PR TITLE
Add travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,10 @@
+language: go
+
+os:
+  - linux
+  - osx
+
+go:
+  - '1.9'
+  - '1.10'
+  - 'tip'


### PR DESCRIPTION
Add `.travis.yml` running tests on OS-X and linux for go1.9, go1.10 and tip