### PR TITLE
Introduce reader.Begin/Done for tx reuse

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ## [Unreleased]
 
 ### Added
+- Add `(*pq.Reader).Begin/Done` to reuse a read transaction for multiple reads. PR #4
 
 ### Changed
 

--- a/pq/testing_test.go
+++ b/pq/testing_test.go
@@ -104,15 +104,19 @@ func (q *testQueue) read(n int) []string {
 		out = make([]string, 0, n)
 	}
 
+	reader := q.Reader()
+	reader.Begin()
+	defer reader.Done()
+
 	for n < 0 || len(out) < n {
-		sz, err := q.Reader().Next()
+		sz, err := reader.Next()
 		q.t.FatalOnError(err)
 		if sz <= 0 {
 			break
 		}
 
 		buf := make([]byte, sz)
-		_, err = q.Reader().Read(buf)
+		_, err = reader.Read(buf)
 		q.t.FatalOnError(err)
 
 		out = append(out, string(buf))


### PR DESCRIPTION
Allow the pq.Reader to reuse a readonly transactions when reading multiple entries. A readers user must use Begin and Done to control the lifetime of the read transaction.

Note: read transactions should not be long-lived, as long-lived transactions can stall write transactions.