### PR TITLE
Fix on-disk checksum error after growing a file

### DIFF
--- a/file.go
+++ b/file.go
@@ -569,7 +569,8 @@ func shrinkFile(f *File, opts Options) error {
 // initTxMaxSize runs a write transaction, updating the file maxSize
 // to the newMaxSize value.
 // initTxMaxSize is used when opening an existing file.
-// On
+// As the file size must be a multiple of the file's page size, the number of
+// maximum pages and the actual max file size is returned on success.
 func initTxMaxSize(
 	f *File,
 	newMaxSize uint64,

--- a/file.go
+++ b/file.go
@@ -545,15 +545,15 @@ func (f Flag) Check(check Flag) bool {
 func growFile(f *File, opts Options) error {
 	maxPages, maxSize, err := initTxMaxSize(f, opts.MaxSize)
 	if err != nil {
-		return fmt.Errorf("growing file transaction failed with %v", err)
+		return fmt.Errorf("growing max size transaction failed with %v", err)
 	}
 
 	// Transaction completed. Update file allocator limits
 	f.allocator.maxPages = maxPages
 	f.allocator.maxSize = maxSize
 
-	// Allocate space on fisk if prealloc is enabled and new file size is bounded.
-	if !opts.Prealloc && maxSize > 0 {
+	// Allocate space on disk if prealloc is enabled and new file size is bounded.
+	if opts.Prealloc && maxSize > 0 {
 		if err := f.file.Truncate(int64(maxSize)); err != nil {
 			return fmt.Errorf("allocating space on disk failed with %v", err)
 		}

--- a/tx.go
+++ b/tx.go
@@ -363,7 +363,7 @@ func (tx *Tx) tryCommitChanges() error {
 	// 4. sync all new contents and metadata before updating the ondisk meta page.
 	tx.file.writer.Sync(tx.writeSync)
 
-	// 5. finalize on-disk transaction be writing new meta page.
+	// 5. finalize on-disk transaction by writing new meta page.
 	tx.file.wal.fileCommitMeta(newMeta, &csWAL)
 	tx.file.allocator.fileCommitMeta(newMeta, &csAlloc)
 	metaID := tx.syncNewMeta(&newMetaBuf)

--- a/tx.go
+++ b/tx.go
@@ -312,11 +312,9 @@ func (tx *Tx) commitChanges() error {
 func (tx *Tx) tryCommitChanges() error {
 	pending, exclusive := tx.file.locks.Pending(), tx.file.locks.Exclusive()
 
-	var newMetaBuf metaBuf
+	newMetaBuf := tx.prepareMetaBuffer()
 	newMeta := newMetaBuf.cast()
-	*newMeta = *tx.file.getMetaPage()        // init new meta header from current active meta header
-	newMeta.txid.Set(1 + newMeta.txid.Get()) // inc txid
-	newMeta.root.Set(tx.rootID)              // update data root
+	newMeta.root.Set(tx.rootID) // update data root
 
 	// give concurrent read transactions a chance to complete, but don't allow
 	// for new read transactions to start while executing the commit
@@ -368,10 +366,7 @@ func (tx *Tx) tryCommitChanges() error {
 	// 5. finalize on-disk transaction be writing new meta page.
 	tx.file.wal.fileCommitMeta(newMeta, &csWAL)
 	tx.file.allocator.fileCommitMeta(newMeta, &csAlloc)
-	newMeta.Finalize()
-	metaID := 1 - tx.file.metaActive
-	tx.file.writer.Schedule(tx.writeSync, PageID(metaID), newMetaBuf[:])
-	tx.file.writer.Sync(tx.writeSync)
+	metaID := tx.syncNewMeta(&newMetaBuf)
 
 	// 6. wait for all pages beeing written and synced,
 	//    before updating in memory state.
@@ -420,6 +415,23 @@ func (tx *Tx) tryCommitChanges() error {
 	traceln("  wal mapped pages:", len(tx.file.wal.mapping))
 
 	return nil
+}
+
+func (tx *Tx) prepareMetaBuffer() (buf metaBuf) {
+	meta := buf.cast()
+	*meta = *tx.file.getMetaPage()
+	meta.txid.Set(1 + meta.txid.Get())
+	return
+}
+
+func (tx *Tx) syncNewMeta(buf *metaBuf) int {
+	meta := buf.cast()
+	meta.Finalize()
+
+	metaID := 1 - tx.file.metaActive
+	tx.file.writer.Schedule(tx.writeSync, PageID(metaID), (*buf)[:])
+	tx.file.writer.Sync(tx.writeSync)
+	return metaID
 }
 
 func (tx *Tx) commitPrepareWAL() (walCommitState, error) {


### PR DESCRIPTION
When growing a file on Open, the new transaction header's checksum was
not updated. Due to the missing update, re-opening a file after updating
the file size only fails.