### PR TITLE
Add support to reduce the maximum file size

### DIFF
--- a/alloc_test.go
+++ b/alloc_test.go
@@ -184,7 +184,9 @@ func testDataAllocator(assert *assertions, runner allocatorTestRunner) {
 		regions.EachPage(func(id PageID) { allocator.Free(&tx, id) })
 
 		// commit transaction state:
-		state.data.commit(mergeRegionLists(state.data.freelist.regions, tx.data.freed.Regions()))
+		state.data.commit(
+			state.data.endMarker,
+			mergeRegionLists(state.data.freelist.regions, tx.data.freed.Regions()))
 
 		// validate
 		tx = state.makeTxAllocState(false, 0)
@@ -459,8 +461,12 @@ func testMetaAllocator(assert *assertions, runner allocatorTestRunner) {
 		allocator.FreeRegions(&tx, regions)
 
 		// commit transaction state:
-		state.data.commit(mergeRegionLists(state.data.freelist.regions, tx.data.freed.Regions()))
-		state.meta.commit(mergeRegionLists(state.meta.freelist.regions, tx.meta.freed.Regions()))
+		state.data.commit(
+			state.data.endMarker,
+			mergeRegionLists(state.data.freelist.regions, tx.data.freed.Regions()))
+		state.meta.commit(
+			state.meta.endMarker,
+			mergeRegionLists(state.meta.freelist.regions, tx.meta.freed.Regions()))
 
 		// validate
 		tx = state.makeTxAllocState(false, 0)

--- a/freelist.go
+++ b/freelist.go
@@ -361,6 +361,14 @@ func (f *freelist) RemoveRegion(removed region) {
 	f.avail -= total
 }
 
+func (f *freelist) LastRegion() region {
+	L := len(f.regions)
+	if L == 0 {
+		return region{}
+	}
+	return f.regions[L-1]
+}
+
 // (de-)serialization
 
 func readFreeList(

--- a/pageset.go
+++ b/pageset.go
@@ -9,6 +9,21 @@ func (s *pageSet) Add(id PageID) {
 	(*s)[id] = struct{}{}
 }
 
+func (s *pageSet) AddSet(other pageSet) {
+	if *s == nil {
+		*s = pageSet{}
+	}
+	for id := range other {
+		(*s)[id] = struct{}{}
+	}
+}
+
+func (s pageSet) Remove(id PageID) {
+	if s != nil {
+		delete(s, id)
+	}
+}
+
 func (s pageSet) Has(id PageID) bool {
 	if s != nil {
 		_, exists := s[id]

--- a/region.go
+++ b/region.go
@@ -120,6 +120,11 @@ func (r region) EachPage(fn func(PageID)) {
 	}
 }
 
+func (l region) PageIDs() (ids idList) {
+	l.EachPage(ids.Add)
+	return
+}
+
 func (r region) Before(other region) bool {
 	return r.id < other.id
 }

--- a/tx.go
+++ b/tx.go
@@ -551,7 +551,10 @@ func (tx *Tx) rollbackChanges() error {
 	if uint(sz) > uint(truncateSz) {
 		// ignore truncate error, as truncating a memory mapped file might not be
 		// supported by all OSes/filesystems.
-		tx.file.file.Truncate(int64(truncateSz))
+		err := tx.file.file.Truncate(int64(truncateSz))
+		if err != nil {
+			traceln("rollback file truncate failed with:", err)
+		}
 	}
 
 	return nil

--- a/tx.go
+++ b/tx.go
@@ -337,7 +337,7 @@ func (tx *Tx) tryCommitChanges() error {
 	}
 
 	var csAlloc allocCommitState
-	tx.file.allocator.fileCommitPrepare(&csAlloc, &tx.alloc)
+	tx.file.allocator.fileCommitPrepare(&csAlloc, &tx.alloc, false)
 
 	// 2. allocate new file pages for new meta data to be written
 	if err := tx.file.wal.fileCommitAlloc(tx, &csWAL); err != nil {
@@ -393,15 +393,32 @@ func (tx *Tx) tryCommitChanges() error {
 	// Switch the files active meta page to meta page being written.
 	tx.file.metaActive = metaID
 
-	// check + apply mmap update. If we fail here, the file and internal
-	// state is already updated + valid.
+	// Compare required file size with the real file size and the mmaped region.
+	// If the expected file size of the last transaction is < the real file size,
+	// we can truncate the file and update the mmaped region.
+	// If the expected file size is > the mmaped region, we need to update the mmaped file region.
+	// If we fail here, the file and internal state is already updated + valid.
 	// But mmap failed on us -> fatal error
+	mmapRequired := false
+
 	endMarker := tx.file.allocator.data.endMarker
 	if metaEnd := tx.file.allocator.meta.endMarker; metaEnd > endMarker {
 		endMarker = metaEnd
 	}
-	fileSize := uint(endMarker) * tx.file.allocator.pageSize
-	if int(fileSize) > len(tx.file.mapped) {
+
+	// compute maximum expected file size of current transaction
+	expectedMMapSize := int64(uint(endMarker) * tx.file.allocator.pageSize)
+	maxSize := int64(tx.file.allocator.maxSize)
+	pageSize := tx.file.allocator.pageSize
+	requiredFileSz, truncate := checkTruncate(&tx.alloc, tx.file.size, expectedMMapSize, maxSize, pageSize)
+	if truncate {
+		if err := tx.file.truncate(requiredFileSz); err == nil {
+			mmapRequired = true
+			tx.file.size = requiredFileSz
+		}
+	}
+
+	if mmapRequired || int(expectedMMapSize) > len(tx.file.mapped) {
 		err = tx.file.mmapUpdate()
 	}
 
@@ -415,6 +432,44 @@ func (tx *Tx) tryCommitChanges() error {
 	traceln("  wal mapped pages:", len(tx.file.wal.mapping))
 
 	return nil
+}
+
+func checkTruncate(
+	st *txAllocState,
+	sz, mmapSz, maxSz int64,
+	pageSize uint,
+) (int64, bool) {
+	if maxSz <= 0 { // file is unbounded, no truncate required
+		return 0, false
+	}
+
+	expectedFileSz := mmapSz
+	if expectedFileSz < maxSz {
+		expectedFileSz = maxSz
+	}
+
+	if expectedFileSz >= sz {
+		// Required size still surpasses the last known file size -> do not
+		// truncate.
+		return 0, false
+	}
+
+	lastEnd := st.data.endMarker
+	if metaEnd := st.meta.endMarker; metaEnd > lastEnd {
+		lastEnd = metaEnd
+	}
+
+	lastExpectedFileSz := int64(uint(lastEnd) * pageSize)
+	if lastExpectedFileSz < maxSz {
+		lastExpectedFileSz = maxSz
+	}
+
+	// Compute minimum required file size for the last two active transactions (maximum).
+	if lastExpectedFileSz > expectedFileSz {
+		expectedFileSz = lastExpectedFileSz
+	}
+
+	return expectedFileSz, expectedFileSz < sz
 }
 
 func (tx *Tx) prepareMetaBuffer() (buf metaBuf) {


### PR DESCRIPTION
Requires: #11

- Implement support for reducing the maximum file size. The change defers the truncate
  truncate until last 2 transactions agree the file can be truncated.
  If no pages are allocated or freed, the truncate check will not be
  run, so to keep the old/known file size and page allocation
  states.
- Add some more helpers to pageSet, region types
- Add more file resize tests