### PR TITLE
Improve Windows support

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,0 +1,56 @@
+# Version format
+version: "{build}"
+
+
+image: Visual Studio 2015
+
+# Environment variables
+environment:
+  GOPATH: c:\gopath
+  GVM_GO_VERSION: 1.10.2
+  GVM_DL: https://github.com/andrewkroh/gvm/releases/download/v0.0.5/gvm-windows-amd64.exe
+
+# Custom clone folder (variables are not expanded here).
+clone_folder: c:\gopath\src\github.com\elastic\go-txfile
+
+# Cache mingw install until appveyor.yml is modified.
+cache:
+- C:\ProgramData\chocolatey\bin -> .appveyor.yml
+- C:\ProgramData\chocolatey\lib -> .appveyor.yml
+- C:\Users\appveyor\.gvm -> .appveyor.yml
+- C:\Windows\System32\gvm.exe -> .appveyor.yml
+
+# Scripts that run after cloning repository
+install:
+  - ps: >-
+      if(!(Test-Path "C:\Windows\System32\gvm.exe")) {
+        wget "$env:GVM_DL" -Outfile C:\Windows\System32\gvm.exe
+      }
+  - ps: gvm --format=powershell "$env:GVM_GO_VERSION" | Invoke-Expression
+  # AppVeyor has MinGW64. Make sure it's on the PATH.
+  - set PATH=C:\mingw-w64\x86_64-7.2.0-posix-seh-rt_v5-rev1;%GOROOT%\bin;%PATH%
+  - set PATH=%GOPATH%\bin;%PATH%
+  - go version
+  - go env
+  - python --version
+before_build:
+
+build_script:
+  # Compile
+  - appveyor AddCompilationMessage "Starting Compile"
+  - cd c:\gopath\src\github.com\elastic\go-txfile
+  - go get -v -t -d ./...
+  - go build
+  - appveyor AddCompilationMessage "Compile Success"
+
+test_script:
+  # Unit tests
+  - ps: Add-AppveyorTest "Unit Tests" -Outcome Running
+  - go test -v github.com/elastic/go-txfile/...
+  - ps: Update-AppveyorTest "Unit Tests" -Outcome Passed
+
+# To disable deployment
+deploy: off
+
+# Notifications should only be setup using the AppVeyor UI so that
+# forks can be created without inheriting the settings.

--- a/file_other.go
+++ b/file_other.go
@@ -1,0 +1,9 @@
+// +build darwin dragonfly freebsd linux netbsd openbsd solaris
+
+package txfile
+
+// computePlatformMmapSize computes the maximum amount of bytes to be mmaped,
+// depending on the actual file size and the configured maximum file size.
+func computePlatformMmapSize(fileSize, maxSize, pageSize uint) (uint, error) {
+	return computeMmapSize(fileSize, maxSize, pageSize)
+}

--- a/file_test.go
+++ b/file_test.go
@@ -65,6 +65,7 @@ func TestTxFile(t *testing.T) {
 		path, teardown := setupPath(assert, "")
 		defer teardown()
 
+		assert.Log("create and close file")
 		f, err := Open(path, os.ModePerm, Options{
 			MaxSize:  10 * 1 << 20, // 10MB
 			PageSize: 4096,
@@ -74,6 +75,7 @@ func TestTxFile(t *testing.T) {
 
 		// check if we can re-open the file:
 
+		assert.Log("open and close existing file")
 		f, err = Open(path, os.ModePerm, Options{})
 		assert.FatalOnError(err)
 		assert.NoError(f.Close())

--- a/file_windows.go
+++ b/file_windows.go
@@ -1,0 +1,16 @@
+package txfile
+
+// computePlatformMmapSize computes the maximum amount of bytes to be mmaped,
+// depending on the actual file size and the configured maximum file size.
+// On Windows, the size returned MUST NOT exceed the actual file size.
+func computePlatformMmapSize(fileSize, maxSize, pageSize uint) (uint, error) {
+	if maxSize == 0 {
+		return fileSize, nil
+	}
+
+	sz, err := computeMmapSize(fileSize, maxSize, pageSize)
+	if fileSize < sz {
+		sz = fileSize
+	}
+	return sz, err
+}

--- a/internal/vfs/osfs/lock_windows.go
+++ b/internal/vfs/osfs/lock_windows.go
@@ -24,7 +24,7 @@ func (f *File) Lock(exclusive, blocking bool) error {
 	lock := flock.NewFlock(f.Name() + lockExt)
 	if blocking {
 		err = lock.Lock()
-		ok = err != nil
+		ok = err == nil
 	} else {
 		ok, err = lock.TryLock()
 	}
@@ -49,6 +49,5 @@ func (f *File) Unlock() error {
 	if err == nil {
 		f.state.lock.Flock = nil
 	}
-
 	return err
 }

--- a/internal/vfs/osfs/mmap_windows.go
+++ b/internal/vfs/osfs/mmap_windows.go
@@ -13,8 +13,8 @@ type mmapState struct {
 }
 
 func (f *File) MMap(sz int) ([]byte, error) {
-	szhi, szlo := uint32(sz>>32), uint32(sz)
-	hdl, err := windows.CreateFileMapping(windows.Handle(f.Fd()), nil, windows.PAGE_READONLY, szhi, szlo, nil)
+	szHi, szLo := uint32(sz>>32), uint32(sz)
+	hdl, err := windows.CreateFileMapping(windows.Handle(f.Fd()), nil, windows.PAGE_READONLY, szHi, szLo, nil)
 	if hdl == 0 {
 		return nil, os.NewSyscallError("CreateFileMapping", err)
 	}

--- a/txfiletest/txfiletest.go
+++ b/txfiletest/txfiletest.go
@@ -68,7 +68,7 @@ func (f *TestFile) Open() {
 
 	tmp, err := txfile.Open(f.Path, os.ModePerm, f.opts)
 	if err != nil {
-		f.t.Fatal("reopen failed")
+		f.t.Fatal("open failed:", err)
 	}
 	f.File = tmp
 }


### PR DESCRIPTION
This PR adds CI using appveyor and a few fixes for using txfile on Windows:
- Add missing file unlock on close, so file can be reopened and locked
- Ensure memory mapped area does not exceed the file size on Windows. If the file is not preallocated, growing the file requires the mmaped area to be updated. This can cause performance degradations if the file is not preallocated.