### PR TITLE
Add support for transaction metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ## [Unreleased]
 
 ### Added
+- Added `Observer` to txfile for collecting per transaction metrics. PR #23
 
 ### Changed
 

--- a/alloc.go
+++ b/alloc.go
@@ -89,6 +89,7 @@ type (
 		data    txAllocArea
 		meta    txAllocArea
 		options txAllocOptions // per transaction allocation options
+		stats   txAllocStats
 	}
 
 	txAllocArea struct {
@@ -106,6 +107,17 @@ type (
 	txAllocOptions struct {
 		overflowAreaEnabled bool // enable allocating pages with ID > maxPages for metadata
 		metaGrowPercentage  int  // limit of meta area in use, so to allocate new pages into the meta area
+	}
+
+	txAllocStats struct {
+		data     txAllocAreaStats
+		meta     txAllocAreaStats
+		overflow txAllocAreaStats // overflow region allocations/frees
+		toMeta   uint             // number of pages moved from data area to meta area
+	}
+
+	txAllocAreaStats struct {
+		alloc, freed uint
 	}
 )
 
@@ -164,9 +176,6 @@ func (a *allocator) fileCommitPrepare(
 ) {
 	st.tx = tx
 	st.updated = forceUpdate || tx.Updated()
-	if st.updated {
-		a.MetaAllocator().FreeRegions(tx, a.freelistPages)
-	}
 }
 
 func (a *allocator) fileCommitAlloc(st *allocCommitState) reason {
@@ -222,6 +231,8 @@ func (a *allocator) fileCommitAlloc(st *allocCommitState) reason {
 	// Remove pages from end of overflow area from meta freelist + adjust end marker
 	st.metaList, st.overflowFreed = releaseOverflowPages(newMetaList, a.maxPages, metaEndMarker)
 	if st.overflowFreed > 0 {
+		st.tx.stats.overflow.freed += st.overflowFreed
+
 		newEnd := metaEndMarker - PageID(st.overflowFreed)
 		if metaEndMarker > dataEndMarker { // shrink overflow area, which was allocated from data area
 			dataEndMarker = newEnd
@@ -373,6 +384,21 @@ func (a *allocArea) rollback(st *txAllocArea) {
 // metaManager
 // -----------
 
+func (mm *metaManager) onGrow(st *txAllocState, n uint, overflow bool) {
+	if overflow {
+		st.stats.overflow.alloc += n
+	}
+	st.stats.toMeta += n
+}
+
+func (mm *metaManager) onAlloc(st *txAllocState, n uint) {
+	st.stats.meta.alloc++
+}
+
+func (mm *metaManager) onFree(st *txAllocState, n uint) {
+	st.stats.meta.freed++
+}
+
 func (mm *metaManager) DataAllocator() *dataAllocator {
 	return (*dataAllocator)(mm)
 }
@@ -449,9 +475,7 @@ func (mm *metaManager) tryGrow(
 		}
 
 		da.AllocRegionsWith(st, avail, func(reg region) {
-			st.manager.moveToMeta.Add(reg)
-			mm.metaTotal += uint(reg.count)
-			mm.meta.freelist.AddRegion(reg)
+			mm.transferToMeta(st, reg)
 		})
 
 		// allocate from overflow area
@@ -461,7 +485,9 @@ func (mm *metaManager) tryGrow(
 		}
 		allocFromArea(&st.meta, &mm.meta.endMarker, required, func(reg region) {
 			// st.manager.fromOverflow.Add(reg)
-			mm.metaTotal += uint(reg.count)
+			n := uint(reg.count)
+			mm.onGrow(st, n, true)
+			mm.metaTotal += n
 			mm.meta.freelist.AddRegion(reg)
 		})
 		if mm.maxPages == 0 && mm.data.endMarker < mm.meta.endMarker {
@@ -474,23 +500,28 @@ func (mm *metaManager) tryGrow(
 	// Enough memory available in data area. Try to allocate continuous region first
 	reg := da.AllocContinuousRegion(st, count)
 	if reg.id != 0 {
-		st.manager.moveToMeta.Add(reg)
-		mm.metaTotal += uint(reg.count)
-		mm.meta.freelist.AddRegion(reg)
+		mm.transferToMeta(st, reg)
 		return true
 	}
 
 	// no continuous memory block -> allocate single regions
 	n := da.AllocRegionsWith(st, count, func(reg region) {
-		st.manager.moveToMeta.Add(reg)
-		mm.metaTotal += uint(reg.count)
-		mm.meta.freelist.AddRegion(reg)
+		mm.transferToMeta(st, reg)
 	})
 	return n == count
 }
 
+func (mm *metaManager) transferToMeta(st *txAllocState, reg region) {
+	n := uint(reg.count)
+	st.manager.moveToMeta.Add(reg)
+	mm.onGrow(st, n, false)
+	mm.metaTotal += uint(reg.count)
+	mm.meta.freelist.AddRegion(reg)
+}
+
 func (mm *metaManager) Free(st *txAllocState, id PageID) {
 	// mark page as freed for now
+	mm.onFree(st, 1)
 	st.meta.freed.Add(id)
 }
 
@@ -540,6 +571,14 @@ func (a *dataAllocator) Avail(_ *txAllocState) uint {
 	return avail
 }
 
+func (a *dataAllocator) onAlloc(st *txAllocState, n uint) {
+	st.stats.data.alloc += n
+}
+
+func (a *dataAllocator) onFree(st *txAllocState, n uint) {
+	st.stats.data.freed += n
+}
+
 func (a *dataAllocator) AllocContinuousRegion(
 	st *txAllocState,
 	n uint,
@@ -551,6 +590,7 @@ func (a *dataAllocator) AllocContinuousRegion(
 
 	reg := allocContFromFreelist(&a.data.freelist, &st.data, allocFromBeginning, n)
 	if reg.id != 0 {
+		a.onAlloc(st, n)
 		return reg
 	}
 
@@ -564,6 +604,8 @@ func (a *dataAllocator) AllocContinuousRegion(
 	if a.meta.endMarker < a.data.endMarker {
 		a.meta.endMarker = a.data.endMarker
 	}
+
+	a.onAlloc(st, n)
 	return reg
 }
 
@@ -589,6 +631,8 @@ func (a *dataAllocator) AllocRegionsWith(
 			a.meta.endMarker = a.data.endMarker
 		}
 	}
+
+	a.onAlloc(st, count)
 	return count
 }
 
@@ -598,6 +642,8 @@ func (a *dataAllocator) Free(st *txAllocState, id PageID) {
 	if id < 2 || id >= a.data.endMarker {
 		panic(fmt.Sprintf("freed page ID %v out of bounds", id))
 	}
+
+	a.onFree(st, 1)
 
 	if !st.data.new.Has(id) {
 		// fast-path, page has not been allocated in current transaction
@@ -656,6 +702,8 @@ func (a *walAllocator) Alloc(st *txAllocState) PageID {
 	if reg.id == 0 {
 		return 0
 	}
+
+	mm.onAlloc(st, 1)
 	st.meta.allocated.Add(reg.id)
 	return reg.id
 }
@@ -666,7 +714,9 @@ func (a *walAllocator) AllocRegionsWith(st *txAllocState, n uint, fn func(region
 		return 0
 	}
 
-	return allocFromFreelist(&a.meta.freelist, &st.meta, allocFromBeginning, n, fn)
+	count := allocFromFreelist(&a.meta.freelist, &st.meta, allocFromBeginning, n, fn)
+	mm.onAlloc(st, count)
+	return count
 }
 
 func (a *walAllocator) Free(st *txAllocState, id PageID) {
@@ -692,7 +742,9 @@ func (a *metaAllocator) AllocRegionsWith(
 		return 0
 	}
 
-	return allocFromFreelist(&a.meta.freelist, &st.meta, allocFromEnd, n, fn)
+	count := allocFromFreelist(&a.meta.freelist, &st.meta, allocFromEnd, n, fn)
+	mm.onAlloc(st, count)
+	return count
 }
 
 func (a *metaAllocator) AllocRegions(st *txAllocState, n uint) regionList {

--- a/observe.go
+++ b/observe.go
@@ -59,7 +59,7 @@ type FileStats struct {
 
 // TxStats contains common statistics collected during the life-cycle of a transaction.
 type TxStats struct {
-	Readonly  bool          // set if transactoin is readonly. In this case only Duration, Total and Accessed will be set.
+	Readonly  bool          // set if transaction is readonly. In this case only Duration, Total and Accessed will be set.
 	Commit    bool          // If set reported stats will be affective in future file operations. Otherwise allocation stats will have no effect.
 	Duration  time.Duration // total duration the transaction was live
 	Total     uint          // total number of pages accessed(written, read, changed) during the transaction

--- a/observe.go
+++ b/observe.go
@@ -1,0 +1,71 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package txfile
+
+import "time"
+
+// Observer defines common callbacks to observe errors, transactions and other
+// state changes in txfile. The callbacks must not block, so to not block any
+// file operations.
+type Observer interface {
+
+	// OnOpen reports initial file stats when successfully open a file.
+	//
+	// Memory stats are reported in sizes. Page counts can be derived by dividing
+	// the sizes by pageSz.
+	//
+	// Derived metrics:
+	//   dataAreaSz = maxSz - metaAreaSz       // total data area size
+	//   dataAreaActive = dataAreaSz - avail   // data area bytes currently in use
+	OnOpen(stats FileStats)
+
+	// OnBegin reports the start of a new transaction.
+	OnTxBegin(readonly bool)
+
+	// OnClose is used to signal the end of a transaction.
+	//
+	// If readonly is set, the transaction we a readonly transaction. Only the
+	// Duration, Total, and Accessed fields will be set.
+	// Only if `commit` is set will the reported stats be affective in upcoming
+	// file operations (pages written/freed).
+	OnTxClose(file FileStats, tx TxStats)
+}
+
+// FileStats reports the current file state like version and allocated/free space.
+type FileStats struct {
+	Version       uint32 // lates file-header version
+	Size          uint64 // actual file size (changes if file did grow dynamically due to allocations)
+	MaxSize       uint64 // max file size as stores in file header
+	PageSize      uint32 // file page size
+	MetaArea      uint   // total pages reserved for the meta area
+	DataAllocated uint   // data pages in use
+	MetaAllocated uint   // meta pages in use
+}
+
+// TxStats contains common statistics collected during the life-cycle of a transaction.
+type TxStats struct {
+	Readonly  bool          // set if transactoin is readonly. In this case only Duration, Total and Accessed will be set.
+	Commit    bool          // If set reported stats will be affective in future file operations. Otherwise allocation stats will have no effect.
+	Duration  time.Duration // total duration the transaction was live
+	Total     uint          // total number of pages accessed(written, read, changed) during the transaction
+	Accessed  uint          // number of accessed existing pages (read)
+	Allocated uint          // temporarily allocated pages
+	Freed     uint          // total number of freed pages
+	Written   uint          // total number of pages being written to
+	Updated   uint          // number of pages with changed contents
+}

--- a/observe_test.go
+++ b/observe_test.go
@@ -34,9 +34,9 @@ type statEntry struct {
 type statKind uint8
 
 const (
-	kOnOpen statKind = iota
-	kOnTxBegin
-	kOnTxClose
+	statOnOpen statKind = iota
+	statOnTxBegin
+	statOnTxClose
 )
 
 type testObserveLast statEntry
@@ -77,7 +77,7 @@ func TestObserveStats(t *testing.T) {
 		var inuse []PageID
 		{
 			tx := f.Begin()
-			assert.Equal(kOnTxBegin, stat.kind)
+			assert.Equal(statOnTxBegin, stat.kind)
 			defer tx.Close()
 
 			// allocate + commit
@@ -116,7 +116,7 @@ func TestObserveStats(t *testing.T) {
 		// 2. transaction releasing the first 2 allocated pages -> force meta data
 		{
 			tx := f.Begin()
-			assert.Equal(kOnTxBegin, stat.kind)
+			assert.Equal(statOnTxBegin, stat.kind)
 			defer tx.Close()
 
 			// free first 2 allocated pages + commit
@@ -211,7 +211,7 @@ func TestObserveStats(t *testing.T) {
 		defer teardown()
 
 		tx := f.Begin()
-		assert.Equal(kOnTxBegin, stat.kind)
+		assert.Equal(statOnTxBegin, stat.kind)
 		defer tx.Close()
 
 		// allocate + write
@@ -240,28 +240,28 @@ func TestObserveStats(t *testing.T) {
 
 func (t *testObserveLast) OnOpen(stats FileStats) {
 	*t = testObserveLast(statEntry{
-		kind: kOnOpen,
+		kind: statOnOpen,
 		file: stats,
 	})
 }
 
 func (t *testObserveLast) OnTxBegin(readonly bool) {
 	*t = testObserveLast(statEntry{
-		kind:     kOnTxBegin,
+		kind:     statOnTxBegin,
 		readonly: readonly,
 	})
 }
 
 func (t *testObserveLast) OnTxClose(file FileStats, tx TxStats) {
 	*t = testObserveLast(statEntry{
-		kind: kOnTxClose,
+		kind: statOnTxClose,
 		file: file,
 		tx:   tx,
 	})
 }
 
 func checkOpenStat(assert *assertions, expected FileStats, actual statEntry, msg ...interface{}) {
-	assert.Equal(kOnOpen, actual.kind, msg...)
+	assert.Equal(statOnOpen, actual.kind, msg...)
 	checkFileStat(assert, expected, actual, msg...)
 }
 
@@ -272,7 +272,7 @@ func checkFileStat(assert *assertions, expected FileStats, actual statEntry, msg
 func checkTxStat(assert *assertions, expected TxStats, actual statEntry, msg ...interface{}) {
 	txActual := actual.tx
 
-	assert.Equal(kOnTxClose, actual.kind, "invalid stat type")
+	assert.Equal(statOnTxClose, actual.kind, "invalid stat type")
 	assert.True(txActual.Duration > 0, "duration should not be 0")
 
 	txActual.Duration = 0

--- a/observe_test.go
+++ b/observe_test.go
@@ -89,6 +89,8 @@ func TestObserveStats(t *testing.T) {
 				inuse = append(inuse, page.ID())
 				page.SetBytes([]byte{1, 2, 3, 4})
 			}
+
+			time.Sleep(500 * time.Millisecond)
 			assert.NoError(tx.Commit())
 
 			// validate last tx stats
@@ -129,6 +131,8 @@ func TestObserveStats(t *testing.T) {
 				assert.NoError(p.Free())
 			}
 			inuse = inuse[2:]
+
+			time.Sleep(500 * time.Millisecond)
 			assert.NoError(tx.Commit())
 
 			// validate
@@ -190,6 +194,8 @@ func TestObserveStats(t *testing.T) {
 					assert.NoError(err)
 				}
 			}
+
+			time.Sleep(500 * time.Millisecond)
 		})
 		if assert.Failed() {
 			return
@@ -223,6 +229,8 @@ func TestObserveStats(t *testing.T) {
 			page.SetBytes([]byte{1, 2, 3, 4})
 		}
 		assert.NoError(tx.Flush())
+
+		time.Sleep(500 * time.Millisecond)
 		assert.NoError(tx.Rollback()) // rollback after write
 
 		// validate
@@ -273,9 +281,10 @@ func checkTxStat(assert *assertions, expected TxStats, actual statEntry, msg ...
 	txActual := actual.tx
 
 	assert.Equal(statOnTxClose, actual.kind, "invalid stat type")
-	assert.True(txActual.Duration > 0, "duration should not be 0")
 
+	assert.True(txActual.Duration > 0, "duration should not be 0")
 	txActual.Duration = 0
+
 	assert.Equal(expected, txActual, msg...)
 }
 

--- a/observe_test.go
+++ b/observe_test.go
@@ -1,0 +1,323 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package txfile
+
+import (
+	"testing"
+	"time"
+)
+
+type recording []statEntry
+
+type statEntry struct {
+	kind     statKind
+	readonly bool
+	file     FileStats
+	tx       TxStats
+}
+
+type statKind uint8
+
+const (
+	kOnOpen statKind = iota
+	kOnTxBegin
+	kOnTxClose
+)
+
+type testObserveLast statEntry
+
+func TestObserveStats(t *testing.T) {
+	assert := newAssertions(t)
+
+	setupFileWith := func(assert *assertions, stat *statEntry) (*testFile, func()) {
+		return setupTestFile(assert, Options{
+			Observer: (*testObserveLast)(stat),
+			MaxSize:  10 * 1 << 20, // 10 MB
+		})
+	}
+
+	initStat := FileStats{
+		Version:  1,
+		Size:     4096 * 2,
+		MaxSize:  10 * 1 << 20,
+		PageSize: 4096,
+	}
+
+	assert.Run("new file", func(assert *assertions) {
+		var stat statEntry
+		_, teardown := setupFileWith(assert, &stat)
+		defer teardown()
+
+		checkOpenStat(assert, initStat, stat)
+	})
+
+	assert.Run("allocate and free pages", func(assert *assertions) {
+		var stat statEntry
+		f, teardown := setupFileWith(assert, &stat)
+		defer teardown()
+
+		activeFStat := initStat
+
+		// 1. transaction allocating 4 pages
+		var inuse []PageID
+		{
+			tx := f.Begin()
+			assert.Equal(kOnTxBegin, stat.kind)
+			defer tx.Close()
+
+			// allocate + commit
+			pages, err := tx.AllocN(4)
+			if !assert.NoError(err) {
+				return
+			}
+			for _, page := range pages {
+				inuse = append(inuse, page.ID())
+				page.SetBytes([]byte{1, 2, 3, 4})
+			}
+			assert.NoError(tx.Commit())
+
+			// validate last tx stats
+			activeFStat = updFileStats(activeFStat, FileStats{
+				Size:          6 * 4096,
+				DataAllocated: 4,
+			})
+			checkFileStat(assert, activeFStat, stat, "invalid file stats after alloc only tx")
+			checkTxStat(assert, TxStats{
+				Readonly:  false,
+				Commit:    true,
+				Total:     4,
+				Accessed:  0,
+				Allocated: 4,
+				Written:   4,
+			}, stat, "invalid tx stats after alloc only tx")
+
+			f.Reopen()
+			checkOpenStat(assert, activeFStat, stat, "invalid file stats after reopen")
+			if assert.Failed() {
+				return
+			}
+		}
+
+		// 2. transaction releasing the first 2 allocated pages -> force meta data
+		{
+			tx := f.Begin()
+			assert.Equal(kOnTxBegin, stat.kind)
+			defer tx.Close()
+
+			// free first 2 allocated pages + commit
+			for _, id := range inuse[:2] {
+				p, err := tx.Page(id)
+				if !assert.NoError(err) {
+					return
+				}
+
+				assert.NoError(p.Free())
+			}
+			inuse = inuse[2:]
+			assert.NoError(tx.Commit())
+
+			// validate
+			activeFStat = updFileStats(activeFStat, FileStats{
+				DataAllocated: 2,
+				MetaAllocated: 1,
+				MetaArea:      2,
+				Size:          activeFStat.Size + 2*4096,
+			})
+			checkFileStat(assert, activeFStat, stat, "invalid file stat after free tx")
+			checkTxStat(assert, TxStats{
+				Readonly:  false,
+				Commit:    true,
+				Total:     1,
+				Accessed:  0,
+				Allocated: 0,
+				Freed:     2,
+				Written:   1, // note: write of meta data page
+			}, stat, "invalid tx stats after free only tx")
+
+			f.Reopen()
+			checkOpenStat(assert, activeFStat, stat, "invalid file stats after reopen with free list in middle of data area")
+			if assert.Failed() {
+				return
+			}
+		}
+	})
+
+	assert.Run("readonly transaction", func(assert *assertions) {
+		var stat statEntry
+		f, teardown := setupFileWith(assert, &stat)
+		defer teardown()
+
+		// prepare
+		var inuse []PageID
+		f.withTx(true, func(tx *Tx) {
+			pages, err := tx.AllocN(4)
+			if !assert.NoError(err) {
+				return
+			}
+
+			for _, page := range pages {
+				inuse = append(inuse, page.ID())
+				page.SetBytes([]byte{1, 2, 3, 4})
+			}
+
+			assert.NoError(tx.Commit())
+		})
+		if assert.Failed() {
+			return
+		}
+
+		// read a few pages
+		f.withTx(false, func(tx *Tx) {
+			for _, id := range inuse {
+				p, err := tx.Page(id)
+				if assert.NoError(err) {
+					_, err := p.Bytes()
+					assert.NoError(err)
+				}
+			}
+		})
+		if assert.Failed() {
+			return
+		}
+
+		// validate
+		checkTxStat(assert, TxStats{
+			Readonly: true,
+			Commit:   false,
+			Total:    4,
+			Accessed: 4,
+		}, stat, "invalid tx stats after alloc only tx")
+
+	})
+
+	assert.Run("rollback does not change file stats", func(assert *assertions) {
+		var stat statEntry
+		f, teardown := setupFileWith(assert, &stat)
+		defer teardown()
+
+		tx := f.Begin()
+		assert.Equal(kOnTxBegin, stat.kind)
+		defer tx.Close()
+
+		// allocate + write
+		pages, err := tx.AllocN(4)
+		if !assert.NoError(err) {
+			return
+		}
+		for _, page := range pages {
+			page.SetBytes([]byte{1, 2, 3, 4})
+		}
+		assert.NoError(tx.Flush())
+		assert.NoError(tx.Rollback()) // rollback after write
+
+		// validate
+		checkFileStat(assert, initStat, stat, "invalid file stats after rollback tx")
+		checkTxStat(assert, TxStats{
+			Readonly:  false,
+			Commit:    false,
+			Total:     4,
+			Accessed:  0,
+			Allocated: 4,
+			Written:   4,
+		}, stat, "invalid tx stats after rollback with writes")
+	})
+}
+
+func (t *testObserveLast) OnOpen(stats FileStats) {
+	*t = testObserveLast(statEntry{
+		kind: kOnOpen,
+		file: stats,
+	})
+}
+
+func (t *testObserveLast) OnTxBegin(readonly bool) {
+	*t = testObserveLast(statEntry{
+		kind:     kOnTxBegin,
+		readonly: readonly,
+	})
+}
+
+func (t *testObserveLast) OnTxClose(file FileStats, tx TxStats) {
+	*t = testObserveLast(statEntry{
+		kind: kOnTxClose,
+		file: file,
+		tx:   tx,
+	})
+}
+
+func checkOpenStat(assert *assertions, expected FileStats, actual statEntry, msg ...interface{}) {
+	assert.Equal(kOnOpen, actual.kind, msg...)
+	checkFileStat(assert, expected, actual, msg...)
+}
+
+func checkFileStat(assert *assertions, expected FileStats, actual statEntry, msg ...interface{}) {
+	assert.Equal(expected, actual.file, msg...)
+}
+
+func checkTxStat(assert *assertions, expected TxStats, actual statEntry, msg ...interface{}) {
+	txActual := actual.tx
+
+	assert.Equal(kOnTxClose, actual.kind, "invalid stat type")
+	assert.True(txActual.Duration > 0, "duration should not be 0")
+
+	txActual.Duration = 0
+	assert.Equal(expected, txActual, msg...)
+}
+
+func updFileStats(orig, upd FileStats) FileStats {
+	sel64 := func(orig, upd uint64) uint64 {
+		if upd != 0 {
+			return upd
+		}
+		return orig
+	}
+
+	sel := func(orig, upd uint) uint { return uint(sel64(uint64(orig), uint64(upd))) }
+	sel32 := func(orig, upd uint32) uint32 { return uint32(sel64(uint64(orig), uint64(upd))) }
+
+	return FileStats{
+		Version:       sel32(orig.Version, upd.Version),
+		Size:          sel64(orig.Size, upd.Size),
+		MaxSize:       sel64(orig.MaxSize, upd.MaxSize),
+		PageSize:      sel32(orig.PageSize, upd.PageSize),
+		MetaArea:      sel(orig.MetaArea, upd.MetaArea),
+		DataAllocated: sel(orig.DataAllocated, upd.DataAllocated),
+		MetaAllocated: sel(orig.MetaAllocated, upd.MetaAllocated),
+	}
+}
+
+func updTxStats(orig, upd TxStats) TxStats {
+	sel := func(orig, upd uint) uint {
+		if upd != 0 {
+			return upd
+		}
+		return orig
+	}
+
+	return TxStats{
+		Readonly:  upd.Readonly,
+		Commit:    upd.Commit,
+		Duration:  time.Duration(sel(uint(orig.Duration), uint(upd.Duration))),
+		Total:     sel(orig.Total, upd.Total),
+		Accessed:  sel(orig.Accessed, upd.Accessed),
+		Allocated: sel(orig.Allocated, upd.Allocated),
+		Freed:     sel(orig.Freed, upd.Freed),
+		Written:   sel(orig.Written, upd.Written),
+		Updated:   sel(orig.Updated, upd.Updated),
+	}
+}

--- a/opts.go
+++ b/opts.go
@@ -45,6 +45,8 @@ type Options struct {
 
 	// Open file in readonly mode.
 	Readonly bool
+
+	Observer Observer
 }
 
 // Flag configures file opening behavior.

--- a/tx.go
+++ b/tx.go
@@ -402,12 +402,12 @@ func (tx *Tx) finishWith(fn func() reason) reason {
 	}
 	defer tx.close()
 
-	if !tx.flags.readonly {
-		return fn()
-	} else {
+	if tx.flags.readonly {
 		tx.onClose()
+		return nil
 	}
-	return nil
+
+	return fn()
 }
 
 func (tx *Tx) close() {

--- a/tx.go
+++ b/tx.go
@@ -19,6 +19,7 @@ package txfile
 
 import (
 	"sync"
+	"time"
 
 	"github.com/elastic/go-txfile/internal/cleanup"
 	"github.com/elastic/go-txfile/internal/invariant"
@@ -45,6 +46,16 @@ type Tx struct {
 
 	// scheduled WAL updates
 	wal txWalState
+
+	// transaction stats
+	tsStart     time.Time
+	accessStats txAccessStats
+}
+
+type txAccessStats struct {
+	New    uint
+	Read   uint
+	Update uint
 }
 
 // TxOptions adds some per transaction options user can set.
@@ -107,6 +118,96 @@ func newTx(file *File, id uint64, lock sync.Locker, settings TxOptions) *Tx {
 	}
 
 	return tx
+}
+
+func (tx *Tx) onBegin() {
+	o := tx.file.observer
+	if o == nil {
+		return
+	}
+
+	tx.tsStart = time.Now()
+	o.OnTxBegin(tx.flags.readonly)
+}
+
+// onClose is called when a readonly transaction is closed.
+func (tx *Tx) onClose() {
+	o := tx.file.observer
+	if o == nil {
+		return
+	}
+
+	accessed := tx.accessStats.Read
+	o.OnTxClose(tx.file.stats, TxStats{
+		Readonly: true,
+		Duration: time.Since(tx.tsStart),
+		Total:    accessed,
+		Accessed: accessed,
+	})
+}
+
+// onRollback is called when a writable transaction is closed or rolled back without commit.
+func (tx *Tx) onRollback() {
+	o := tx.file.observer
+	if o == nil {
+		return
+	}
+
+	read := tx.accessStats.Read
+	updated := tx.accessStats.Update
+	new := tx.accessStats.New
+
+	o.OnTxClose(tx.file.stats, TxStats{
+		Readonly:  false,
+		Commit:    false,
+		Duration:  time.Since(tx.tsStart),
+		Total:     read + updated + new,
+		Accessed:  read,
+		Updated:   updated,
+		Written:   updated + new,
+		Allocated: tx.alloc.stats.data.alloc,
+		Freed:     tx.alloc.stats.data.freed,
+	})
+}
+
+// onCommit is called after a writable transaction did succeed.
+func (tx *Tx) onCommit() {
+	allocStats := &tx.alloc.stats
+
+	fileStats := &tx.file.stats
+	fileStats.Size = uint64(tx.file.size)
+	fileStats.MetaArea = tx.file.allocator.metaTotal
+	fileStats.MetaAllocated = tx.file.allocator.metaTotal - tx.file.allocator.meta.freelist.Avail()
+	fileStats.DataAllocated += allocStats.data.alloc - allocStats.data.freed - allocStats.toMeta
+
+	o := tx.file.observer
+	if o == nil {
+		return
+	}
+
+	read := tx.accessStats.Read
+	updated := tx.accessStats.Update
+	new := tx.accessStats.New
+
+	o.OnTxClose(tx.file.stats, TxStats{
+		Readonly:  false,
+		Commit:    true,
+		Duration:  time.Since(tx.tsStart),
+		Total:     read + updated + new,
+		Accessed:  read,
+		Allocated: allocStats.data.alloc - allocStats.toMeta,
+		Freed:     allocStats.data.freed,
+		Written:   updated + new,
+		Updated:   updated,
+	})
+}
+
+// onAccess is called when a the memory page pointer is requested.
+func (tx *Tx) onAccess() {
+	tx.accessStats.Read++
+}
+
+func (tx *Tx) onWALTransfer(n int) { // number of wal pages copied  into data area
 }
 
 // Writable returns true if the transaction supports file modifications.
@@ -276,7 +377,7 @@ func (tx *Tx) doCheckpointWAL() {
 	for i := range ids {
 		id, walID := ids[i], walIDS[i]
 
-		contents := tx.file.mmapedPage(walID)
+		contents := tx.access(walID)
 		if contents == nil {
 			panic("invalid WAL mapping")
 		}
@@ -291,6 +392,7 @@ func (tx *Tx) doCheckpointWAL() {
 		tx.freeWALID(id, walID)
 	}
 
+	tx.onWALTransfer(len(ids))
 	tx.flags.checkpoint = true
 }
 
@@ -321,12 +423,14 @@ func (tx *Tx) commitChanges() reason {
 	defer cleanup.IfNot(&commitOK, tx.rollbackChanges)
 
 	err := tx.tryCommitChanges()
-	if commitOK = err == nil; !commitOK {
+	commitOK = err == nil
+	if !commitOK {
 		return err
 	}
 
 	traceMetaPage(tx.file.getMetaPage())
-	return err
+	tx.onCommit()
+	return nil
 }
 
 // tryCommitChanges attempts to write flush all pages written and update the
@@ -358,10 +462,6 @@ func (tx *Tx) tryCommitChanges() reason {
 
 	pending, exclusive := tx.file.locks.Pending(), tx.file.locks.Exclusive()
 
-	newMetaBuf := tx.prepareMetaBuffer()
-	newMeta := newMetaBuf.cast()
-	newMeta.root.Set(tx.rootID) // update data root
-
 	// give concurrent read transactions a chance to complete, but don't allow
 	// for new read transactions to start while executing the commit
 	pending.Lock()
@@ -391,37 +491,13 @@ func (tx *Tx) tryCommitChanges() reason {
 		return err
 	}
 
-	var csAlloc allocCommitState
-	tx.file.allocator.fileCommitPrepare(&csAlloc, &tx.alloc, false)
+	csAlloc := tx.commitPrepareAlloc()
 
-	// 2. allocate new file pages for new meta data to be written
-	if err := tx.file.wal.fileCommitAlloc(tx, &csWAL); err != nil {
-		return err
-	}
-	csAlloc.updated = csAlloc.updated || len(csWAL.allocRegions) > 0
-
-	if err := tx.file.allocator.fileCommitAlloc(&csAlloc); err != nil {
-		return err
-	}
-
-	// 3. serialize page mappings and new freelist
-	err = tx.file.wal.fileCommitSerialize(&csWAL, uint(tx.PageSize()), tx.scheduleWrite)
+	// 2. - 5. Commit changes to file
+	metaID, err := tx.tryCommitChangesToFile(&csWAL, &csAlloc)
 	if err != nil {
 		return err
 	}
-
-	err = tx.file.allocator.fileCommitSerialize(&csAlloc, tx.scheduleWrite)
-	if err != nil {
-		return err
-	}
-
-	// 4. sync all new contents and metadata before updating the ondisk meta page.
-	tx.file.writer.Sync(tx.writeSync, syncDataOnly)
-
-	// 5. finalize on-disk transaction by writing new meta page.
-	tx.file.wal.fileCommitMeta(newMeta, &csWAL)
-	tx.file.allocator.fileCommitMeta(newMeta, &csAlloc)
-	metaID := tx.syncNewMeta(&newMetaBuf)
 
 	// 6. wait for all pages beeing written and synced,
 	//    before updating in memory state.
@@ -488,6 +564,48 @@ func (tx *Tx) tryCommitChanges() reason {
 	return nil
 }
 
+func (tx *Tx) tryCommitChangesToFile(
+	csWAL *walCommitState,
+	csAlloc *allocCommitState,
+) (metaID int, err reason) {
+	newMetaBuf := tx.prepareMetaBuffer()
+	newMeta := newMetaBuf.cast()
+	newMeta.root.Set(tx.rootID) // update data root
+
+	// 2. allocate new file pages for new meta data to be written
+	if err := tx.file.wal.fileCommitAlloc(tx, csWAL); err != nil {
+		return metaID, err
+	}
+	csAlloc.updated = csAlloc.updated || len(csWAL.allocRegions) > 0
+
+	if err := tx.file.allocator.fileCommitAlloc(csAlloc); err != nil {
+		return metaID, err
+	}
+
+	// 3. serialize page mappings and new freelist
+	err = tx.file.wal.fileCommitSerialize(csWAL, uint(tx.PageSize()), tx.scheduleCommitMetaWrite)
+	if err != nil {
+		return metaID, err
+	}
+
+	err = tx.file.allocator.fileCommitSerialize(csAlloc, tx.scheduleCommitMetaWrite)
+	if err != nil {
+		return metaID, err
+	}
+
+	// 4. sync all new contents and metadata before updating the ondisk meta page.
+	tx.file.writer.Sync(tx.writeSync, syncDataOnly)
+
+	// 5. finalize on-disk transaction by writing new meta page.
+	tx.file.wal.fileCommitMeta(newMeta, csWAL)
+	tx.file.allocator.fileCommitMeta(newMeta, csAlloc)
+	metaID = tx.syncNewMeta(&newMetaBuf)
+
+	// 6. wait for all pages beeing written and synced,
+	//    before updating in memory state.
+	return metaID, nil
+}
+
 func checkTruncate(
 	st *txAllocState,
 	sz, mmapSz, maxSz int64,
@@ -552,13 +670,34 @@ func (tx *Tx) commitPrepareWAL() (walCommitState, reason) {
 	}
 
 	if st.updated {
-		tx.metaAllocator().FreeRegions(&tx.alloc, tx.file.wal.metaPages)
+		tx.freeMetaRegions(tx.file.wal.metaPages)
 	}
 	return st, nil
 }
 
+func (tx *Tx) commitPrepareAlloc() (state allocCommitState) {
+	tx.file.allocator.fileCommitPrepare(&state, &tx.alloc, false)
+	if state.updated {
+		tx.freeMetaRegions(tx.file.allocator.freelistPages)
+	}
+	return state
+}
+
+func (tx *Tx) freeMetaRegions(rl regionList) {
+	tx.metaAllocator().FreeRegions(&tx.alloc, rl)
+}
+
 func (tx *Tx) access(id PageID) []byte {
+	tx.onAccess()
 	return tx.file.mmapedPage(id)
+}
+
+// scheduleCommitMetaWrite is used to schedule a page write for the file meta
+// data like free list or page mappings. scheduleCommitMetaWrite must only be
+// used during file updates in the commit phase.
+func (tx *Tx) scheduleCommitMetaWrite(id PageID, buf []byte) reason {
+	tx.accessStats.New++
+	return tx.scheduleWrite(id, buf)
 }
 
 func (tx *Tx) scheduleWrite(id PageID, buf []byte) reason {
@@ -583,6 +722,12 @@ func (tx *Tx) scheduleWrite(id PageID, buf []byte) reason {
 //        - Truncate file only if pages in overflow area have been allocated.
 //        - If maxSize == 0, truncate file to old end marker.
 func (tx *Tx) rollbackChanges() {
+	if tx.Readonly() {
+		tx.onClose()
+	} else {
+		tx.onRollback()
+	}
+
 	tx.file.allocator.Rollback(&tx.alloc)
 
 	maxPages := tx.file.allocator.maxPages
@@ -664,7 +809,7 @@ func (tx *Tx) Alloc() (page *Page, err error) {
 	}
 
 	err = tx.allocPagesWith(op, 1, func(p *Page) { page = p })
-	return
+	return page, err
 }
 
 // AllocN allocates n potentially non-contious, yet empty pages.
@@ -687,6 +832,7 @@ func (tx *Tx) AllocN(n int) (pages []*Page, err error) {
 	if err != nil {
 		return nil, err
 	}
+
 	return pages, nil
 }
 
@@ -714,6 +860,7 @@ func (tx *Tx) allocPagesWith(op string, n int, fn func(*Page)) reason {
 	if count == 0 {
 		return tx.err(op).of(OutOfMemory).reportf("not enough memory to allocate %v data page(s)", n)
 	}
+
 	return nil
 }
 


### PR DESCRIPTION
This change introduces a configurable observer listening for transaction
begin and close events. The callbacks will receive additional IO and
allocation statistics collected throughout the execution of the
transaction.

Note: this PR only targets the top level txfile package.