### PR TITLE
Add support for pq metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 - Added `Observer` to txfile for collecting per transaction metrics. PR #23
 - Make file syncing configurable. PR #29
+- Added `Observer` to pq package for collecting operational metrics. PR #26
 
 ### Changed
 - Queue reader requires explicit transaction start/stop calls. PR #27 

--- a/observe_test.go
+++ b/observe_test.go
@@ -22,8 +22,6 @@ import (
 	"time"
 )
 
-type recording []statEntry
-
 type statEntry struct {
 	kind     statKind
 	readonly bool
@@ -46,7 +44,7 @@ func TestObserveStats(t *testing.T) {
 
 	setupFileWith := func(assert *assertions, stat *statEntry) (*testFile, func()) {
 		return setupTestFile(assert, Options{
-			Observer: (*testObserveLast)(stat),
+			Observer: newTestObserver(stat),
 			MaxSize:  10 * 1 << 20, // 10 MB
 		})
 	}
@@ -244,6 +242,10 @@ func TestObserveStats(t *testing.T) {
 			Written:   4,
 		}, stat, "invalid tx stats after rollback with writes")
 	})
+}
+
+func newTestObserver(stat *statEntry) *testObserveLast {
+	return (*testObserveLast)(stat)
 }
 
 func (t *testObserveLast) OnOpen(stats FileStats) {

--- a/pq/access.go
+++ b/pq/access.go
@@ -80,6 +80,10 @@ func (a *access) rootPage(tx *txfile.Tx) (*txfile.Page, error) {
 	return tx.Page(a.rootID)
 }
 
+func (a *access) RootFileOffset() uintptr {
+	return a.Offset(a.rootID, uintptr(a.rootOff))
+}
+
 // LoadRootPage accesses the queue root page from within the passed write
 // transaction.
 // The Root page it's content is loaded into the write buffer for manipulations.

--- a/pq/ack.go
+++ b/pq/ack.go
@@ -18,6 +18,8 @@
 package pq
 
 import (
+	"time"
+
 	"github.com/elastic/go-txfile"
 	"github.com/elastic/go-txfile/internal/invariant"
 )
@@ -26,6 +28,9 @@ import (
 type acker struct {
 	accessor *access
 	active   bool
+
+	hdrOffset uintptr
+	observer  Observer
 
 	totalEventCount uint
 	totalFreedPages uint
@@ -40,8 +45,14 @@ type ackState struct {
 	read position        // New on-disk read pointer, pointing to first not-yet ACKed event.
 }
 
-func newAcker(accessor *access, cb func(uint, uint)) *acker {
-	return &acker{active: true, accessor: accessor, ackCB: cb}
+func newAcker(accessor *access, off uintptr, o Observer, cb func(uint, uint)) *acker {
+	return &acker{
+		hdrOffset: off,
+		observer:  o,
+		active:    true,
+		accessor:  accessor,
+		ackCB:     cb,
+	}
 }
 
 func (a *acker) close() {
@@ -66,16 +77,34 @@ func (a *acker) handle(n uint) error {
 
 	traceln("acker: pq ack events:", n)
 
+	start := time.Now()
+	events, pages, err := a.cleanup(n)
+	if o := a.observer; o != nil {
+		failed := err != nil
+		o.OnQueueACK(a.hdrOffset, ACKStats{
+			Duration: time.Since(start),
+			Failed:   failed,
+			Events:   events,
+			Pages:    pages,
+		})
+	}
+	return err
+}
+
+func (a *acker) cleanup(n uint) (events uint, pages uint, err error) {
+	const op = "pq/ack-cleanup"
+
 	state, err := a.initACK(n)
+	events, pages = n, uint(len(state.free))
 	if err != nil {
-		return a.errWrap(op, err)
+		return events, pages, a.errWrap(op, err)
 	}
 
 	// start write transaction to free pages and update the next read offset in
 	// the queue root
 	tx, txErr := a.accessor.BeginCleanup()
 	if txErr != nil {
-		return a.errWrap(op, txErr).report("failed to init cleanup tx")
+		return events, pages, a.errWrap(op, txErr).report("failed to init cleanup tx")
 	}
 	defer tx.Close()
 
@@ -83,19 +112,19 @@ func (a *acker) handle(n uint) error {
 	for _, id := range state.free {
 		page, err := tx.Page(id)
 		if err != nil {
-			return a.errWrapPage(op, err, id).report("can not access page to be freed")
+			return events, pages, a.errWrapPage(op, err, id).report("can not access page to be freed")
 		}
 
 		traceln("free page", id)
 		if err := page.Free(); err != nil {
-			return a.errWrapPage(op, err, id).report("releasing page failed")
+			return events, pages, a.errWrapPage(op, err, id).report("releasing page failed")
 		}
 	}
 
 	// update queue header
 	hdrPage, hdr, err := a.accessor.LoadRootPage(tx)
 	if err != nil {
-		return err
+		return events, pages, err
 	}
 	a.accessor.WritePosition(&hdr.head, state.head)
 	a.accessor.WritePosition(&hdr.read, state.read)
@@ -105,7 +134,7 @@ func (a *acker) handle(n uint) error {
 	traceQueueHeader(hdr)
 
 	if err := tx.Commit(); err != nil {
-		return a.errWrap(op, err).report("failed to commit changes")
+		return events, pages, a.errWrap(op, err).report("failed to commit changes")
 	}
 
 	a.totalEventCount += n
@@ -116,7 +145,7 @@ func (a *acker) handle(n uint) error {
 		a.ackCB(n, uint(len(state.free)))
 	}
 
-	return nil
+	return events, pages, nil
 }
 
 // initACK uses a read-transaction to collect pages to be removed from list and

--- a/pq/buffer.go
+++ b/pq/buffer.go
@@ -51,6 +51,9 @@ func newBuffer(pool *pagePool, page *page, pages, pageSize, hdrSz int) *buffer {
 	payloadSz := pageSize - hdrSz
 	avail := payloadSz * pages
 
+	tracef("init writer buffer with pages=%v, pageSize=%v, hdrSize=%v, avail=%v\n",
+		pages, pageSize, hdrSz, avail)
+
 	b := &buffer{
 		head:           nil,
 		tail:           nil,
@@ -101,7 +104,7 @@ func (b *buffer) Append(data []byte) {
 		data = data[n:]
 		b.avail -= n
 
-		tracef("writer: append %v bytes to (page: %v, off: %v)\n", n, b.page.Meta.ID, b.page.Meta.EndOff)
+		tracef("writer: append %v bytes to (page: %v, off: %v, avail: %v)\n", n, b.page.Meta.ID, b.page.Meta.EndOff, b.avail)
 
 		b.page.Meta.EndOff += uint32(n)
 	}

--- a/pq/buffer.go
+++ b/pq/buffer.go
@@ -44,7 +44,7 @@ type buffer struct {
 	eventHdrSize   int
 
 	// stats
-	countPages int
+	countPages uint
 }
 
 func newBuffer(pool *pagePool, page *page, pages, pageSize, hdrSz int) *buffer {
@@ -198,7 +198,7 @@ func (b *buffer) CommitEvent(id uint64) {
 
 // Pages returns start and end page to be serialized.
 // The `end` page must not be serialized
-func (b *buffer) Pages() (start, end *page, n int) {
+func (b *buffer) Pages() (start, end *page, n uint) {
 	if b.head == nil || !b.head.Dirty() {
 		return nil, nil, 0
 	}

--- a/pq/observe.go
+++ b/pq/observe.go
@@ -41,8 +41,9 @@ type FlushStats struct {
 	Failed      bool // set to true if flush operation failed
 	OutOfMemory bool // set to true if flush failed due to the file being full
 
-	Pages  uint // number of pages to be flushed
-	Events uint // number of events to be flushed
+	Pages    uint // number of pages to be flushed
+	Allocate uint // number of pages to allocate during flush operation
+	Events   uint // number of events to be flushed
 
 	BytesTotal uint // total number of bytes written (ignoring headers, just event sizes)
 	BytesMin   uint // size of 'smallest' event in current transaction

--- a/pq/observe.go
+++ b/pq/observe.go
@@ -69,5 +69,5 @@ type ACKStats struct {
 	Failed   bool
 
 	Events uint // number of released events
-	Pages  uint // number of release pages
+	Pages  uint // number of released pages
 }

--- a/pq/observe.go
+++ b/pq/observe.go
@@ -36,7 +36,7 @@ type Observer interface {
 // FlushStats reports internal stats on the most recent flush operation.
 type FlushStats struct {
 	Duration       time.Duration // duration of flush operation
-	Oldest, Newest time.Duration // age of oldest/newest event in buffer
+	Oldest, Newest time.Time     // timestamp of oldest/newest event in buffer
 
 	Failed      bool // set to true if flush operation failed
 	OutOfMemory bool // set to true if flush failed due to the file being full

--- a/pq/observe.go
+++ b/pq/observe.go
@@ -1,0 +1,72 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package pq
+
+import "time"
+
+// Observer defines common callbacks to observe operations, outcomes and stats
+// on queues.
+// Each callback reports the header offset for uniquely identifying a queue in
+// case a file holds many queues.
+type Observer interface {
+	OnInit(headerOffset uintptr, version uint32, available uint64)
+
+	OnQueueFlush(headerOffset uintptr, stats FlushStats)
+
+	OnQueueRead(headerOffset uintptr, stats ReadStats)
+
+	OnQueueACK(headerOffset uintptr, stats ACKStats)
+}
+
+// FlushStats reports internal stats on the most recent flush operation.
+type FlushStats struct {
+	Duration       time.Duration // duration of flush operation
+	Oldest, Newest time.Duration // age of oldest/newest event in buffer
+
+	Failed      bool // set to true if flush operation failed
+	OutOfMemory bool // set to true if flush failed due to the file being full
+
+	Pages  uint // number of pages to be flushed
+	Events uint // number of events to be flushed
+
+	BytesTotal uint // total number of bytes written (ignoring headers, just event sizes)
+	BytesMin   uint // size of 'smallest' event in current transaction
+	BytesMax   uint // size of 'biggest' event in current transaction
+}
+
+// ReadStats reports stats on the most recent transaction for reading events.
+type ReadStats struct {
+	Duration time.Duration // duration of read transaction
+
+	OneTimeTx bool // false if transaction is used to read multiple events
+	Skipped   uint // number of events skipped (e.g. upon error while reading/parsing)
+	Read      uint // number of events read
+
+	BytesTotal uint // total number of bytes read (ignoring headers)
+	BytesMin   uint // size of 'smallest' event in current transaction
+	BytesMax   uint // size of 'biggest' event in current transaction
+}
+
+// ACKStats reports stats on the most recent ACK transaction.
+type ACKStats struct {
+	Duration time.Duration
+	Failed   bool
+
+	Events uint // number of released events
+	Pages  uint // number of release pages
+}

--- a/pq/observe.go
+++ b/pq/observe.go
@@ -54,13 +54,13 @@ type FlushStats struct {
 type ReadStats struct {
 	Duration time.Duration // duration of read transaction
 
-	OneTimeTx bool // false if transaction is used to read multiple events
-	Skipped   uint // number of events skipped (e.g. upon error while reading/parsing)
-	Read      uint // number of events read
+	Skipped uint // number of events skipped (e.g. upon error while reading/parsing)
+	Read    uint // number of events read
 
-	BytesTotal uint // total number of bytes read (ignoring headers)
-	BytesMin   uint // size of 'smallest' event in current transaction
-	BytesMax   uint // size of 'biggest' event in current transaction
+	BytesTotal   uint // total number of bytes read (ignoring headers). Include partially but skipped events
+	BytesSkipped uint // number of event bytes skipped
+	BytesMin     uint // size of 'smallest' event fully read in current transaction
+	BytesMax     uint // size of 'biggest' event fully read in current transaction
 }
 
 // ACKStats reports stats on the most recent ACK transaction.

--- a/pq/observe.go
+++ b/pq/observe.go
@@ -24,7 +24,7 @@ import "time"
 // Each callback reports the header offset for uniquely identifying a queue in
 // case a file holds many queues.
 type Observer interface {
-	OnInit(headerOffset uintptr, version uint32, available uint64)
+	OnQueueInit(headerOffset uintptr, version uint32, available uint)
 
 	OnQueueFlush(headerOffset uintptr, stats FlushStats)
 

--- a/pq/observe_test.go
+++ b/pq/observe_test.go
@@ -50,6 +50,12 @@ const (
 	statOnACK
 )
 
+var isWindows bool
+
+func init() {
+	isWindows = runtime.OS == "windows"
+}
+
 func TestObserveStats(testing *testing.T) {
 	t := mint.NewWith(testing, func(sub *mint.T) func() {
 		pushTracer(mint.NewTestLogTracer(sub, logTracer))
@@ -120,7 +126,10 @@ func TestObserveStats(testing *testing.T) {
 		t.True(stat.flush.Duration > 0, "flush duration should be > 0")
 		t.False(stat.flush.Oldest.IsZero(), "oldest timestamp must not be 0")
 		t.False(stat.flush.Newest.IsZero(), "newest timestamp must not be 0")
-		t.True(stat.flush.Oldest != stat.flush.Newest, "timestamps do not match")
+
+		if isWindows {
+			t.True(stat.flush.Oldest != stat.flush.Newest, "timestamps do match")
+		}
 	}))
 
 	t.Run("big write with implcicit flush", withQueue(func(t *mint.T, qu *testQueue, stat *statEntry) {
@@ -174,7 +183,10 @@ func TestObserveStats(testing *testing.T) {
 		t.True(stat.flush.Duration > 0, "flush duration should be > 0")
 		t.False(stat.flush.Oldest.IsZero(), "oldest timestamp must not be 0")
 		t.False(stat.flush.Newest.IsZero(), "newest timestamp must not be 0")
-		t.True(stat.flush.Oldest != stat.flush.Newest, "timestamps do not match")
+
+		if !isWindows {
+			t.True(stat.flush.Oldest != stat.flush.Newest, "timestamps do match")
+		}
 	}))
 }
 

--- a/pq/observe_test.go
+++ b/pq/observe_test.go
@@ -140,7 +140,7 @@ func TestObserveStats(testing *testing.T) {
 			}
 		}))
 
-		t.Run("implcicit flush", withQueue(func(t *mint.T, qu *testQueue, stat *statEntry) {
+		t.Run("implicit flush", withQueue(func(t *mint.T, qu *testQueue, stat *statEntry) {
 			var msg [5000]byte
 			qu.append(string(msg[:]))
 

--- a/pq/observe_test.go
+++ b/pq/observe_test.go
@@ -345,6 +345,18 @@ func TestObserveStats(testing *testing.T) {
 			}, stat.ack)
 		}))
 
+		t.Run("large events", withQueue(func(t *mint.T, qu *testQueue, stat *statEntry) {
+			qu.append(genEventLen(testPageSize*2.5), genEventLen(testPageSize*1.5))
+			qu.flush()
+
+			t.FatalOnError(qu.ACK(2))
+			t.Equal(ACKStats{
+				Duration: stat.ack.Duration,
+				Failed:   false,
+				Events:   2,
+				Pages:    2, // we only free pages for the first event, so to not mess with the readers local state
+			}, stat.ack)
+		}))
 	})
 }
 
@@ -374,3 +386,7 @@ func (t *testObserveLast) set(off uintptr, kind statKind, e statEntry) {
 }
 
 func (s *statEntry) reset() { *s = statEntry{} }
+
+func genEventLen(n int) string {
+	return string(make([]byte, n))
+}

--- a/pq/observe_test.go
+++ b/pq/observe_test.go
@@ -1,0 +1,206 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package pq
+
+import (
+	"testing"
+
+	txfile "github.com/elastic/go-txfile"
+	"github.com/elastic/go-txfile/internal/mint"
+)
+
+type testObserveLast statEntry
+
+type statEntry struct {
+	kind statKind
+	off  uintptr
+
+	// OnInit statis
+	version   uint32
+	available uint
+
+	// per callback stats
+	flush FlushStats
+	read  ReadStats
+	ack   ACKStats
+}
+
+type statKind uint8
+
+const (
+	statNone statKind = iota
+	statOnOpen
+	statOnFlush
+	statOnRead
+	statOnACK
+)
+
+func TestObserveStats(testing *testing.T) {
+	t := mint.NewWith(testing, func(sub *mint.T) func() {
+		pushTracer(mint.NewTestLogTracer(sub, logTracer))
+		return popTracer
+	})
+
+	withQueue := func(fn func(*mint.T, *testQueue, *statEntry)) func(*mint.T) {
+		return func(t *mint.T) {
+			stat := &statEntry{}
+			qu, teardown := setupQueue(t, config{
+				File: txfile.Options{
+					MaxSize:  128 * 1024, // default file size of 128 pages
+					PageSize: 1024,
+				},
+				Queue: Settings{
+					WriteBuffer: defaultMinPages, // buffer up to 5 pages
+					Observer:    newTestObserver(stat),
+				},
+			})
+			defer teardown()
+
+			stat.reset()
+			fn(t, qu, stat)
+		}
+	}
+
+	t.Run("open empty queue", withQueue(func(t *mint.T, qu *testQueue, stat *statEntry) {
+		qu.Reopen()
+		t.Equal(stat.kind, statOnOpen)
+		t.Equal(int(stat.version), queueVersion) // current version
+		t.Equal(int(stat.available), 0)
+	}))
+
+	t.Run("open non-empty queue", withQueue(func(t *mint.T, qu *testQueue, stat *statEntry) {
+		// write 3 events
+		qu.append("a", "b", "c")
+		qu.flush()
+
+		// validate
+		qu.Reopen()
+		t.Equal(stat.kind, statOnOpen)
+		t.Equal(int(stat.version), queueVersion) // current version
+		t.Equal(int(stat.available), 3)
+	}))
+
+	t.Run("small write with explicit flush", withQueue(func(t *mint.T, qu *testQueue, stat *statEntry) {
+		qu.append("a", "bc", "def")
+		t.Equal(statNone, stat.kind, "unexpected stats update")
+
+		qu.flush()
+		t.Equal(statOnFlush, stat.kind)
+		t.Equal(FlushStats{
+			// do not compare duration and timestamps ;)
+			Duration: stat.flush.Duration,
+			Oldest:   stat.flush.Oldest,
+			Newest:   stat.flush.Newest,
+
+			// validated fields
+			Failed:      false,
+			OutOfMemory: false,
+			Pages:       1,
+			Allocate:    1,
+			Events:      3,
+			BytesTotal:  6,
+			BytesMin:    1,
+			BytesMax:    3,
+		}, stat.flush)
+		t.True(stat.flush.Duration > 0, "flush duration should be > 0")
+		t.False(stat.flush.Oldest.IsZero(), "oldest timestamp must not be 0")
+		t.False(stat.flush.Newest.IsZero(), "newest timestamp must not be 0")
+		t.True(stat.flush.Oldest != stat.flush.Newest, "timestamps do not match")
+	}))
+
+	t.Run("big write with implcicit flush", withQueue(func(t *mint.T, qu *testQueue, stat *statEntry) {
+		var msg [5000]byte
+		qu.append(string(msg[:]))
+
+		t.Equal(statOnFlush, stat.kind)
+		t.Equal(FlushStats{
+			// do not compare duration and timestamps ;)
+			Duration: stat.flush.Duration,
+			Oldest:   stat.flush.Oldest,
+			Newest:   stat.flush.Newest,
+
+			// validated fields
+			Failed:      false,
+			OutOfMemory: false,
+			Pages:       6,
+			Allocate:    6,
+			Events:      1,
+			BytesTotal:  5000,
+			BytesMin:    5000,
+			BytesMax:    5000,
+		}, stat.flush)
+		t.True(stat.flush.Duration > 0, "flush duration should be > 0")
+		t.False(stat.flush.Oldest.IsZero(), "oldest timestamp must not be 0")
+		t.False(stat.flush.Newest.IsZero(), "newest timestamp must not be 0")
+		t.True(stat.flush.Oldest == stat.flush.Newest, "timestamps do not match")
+	}))
+
+	t.Run("flush on close", withQueue(func(t *mint.T, qu *testQueue, stat *statEntry) {
+		qu.append("a", "bc", "def")
+		qu.Close()
+
+		t.Equal(statOnFlush, stat.kind)
+		t.Equal(FlushStats{
+			// do not compare duration and timestamps ;)
+			Duration: stat.flush.Duration,
+			Oldest:   stat.flush.Oldest,
+			Newest:   stat.flush.Newest,
+
+			// validated fields
+			Failed:      false,
+			OutOfMemory: false,
+			Pages:       1,
+			Allocate:    1,
+			Events:      3,
+			BytesTotal:  6,
+			BytesMin:    1,
+			BytesMax:    3,
+		}, stat.flush)
+		t.True(stat.flush.Duration > 0, "flush duration should be > 0")
+		t.False(stat.flush.Oldest.IsZero(), "oldest timestamp must not be 0")
+		t.False(stat.flush.Newest.IsZero(), "newest timestamp must not be 0")
+		t.True(stat.flush.Oldest != stat.flush.Newest, "timestamps do not match")
+	}))
+}
+
+func newTestObserver(stat *statEntry) *testObserveLast {
+	return (*testObserveLast)(stat)
+}
+
+func (t *testObserveLast) OnQueueInit(off uintptr, version uint32, available uint) {
+	t.set(off, statOnOpen, statEntry{version: version, available: available})
+}
+
+func (t *testObserveLast) OnQueueFlush(off uintptr, stats FlushStats) {
+	t.set(off, statOnFlush, statEntry{flush: stats})
+}
+
+func (t *testObserveLast) OnQueueRead(off uintptr, stats ReadStats) {
+	t.set(off, statOnRead, statEntry{read: stats})
+}
+
+func (t *testObserveLast) OnQueueACK(off uintptr, stats ACKStats) {
+	t.set(off, statOnACK, statEntry{ack: stats})
+}
+
+func (t *testObserveLast) set(off uintptr, kind statKind, e statEntry) {
+	*t = testObserveLast(e)
+	t.off, t.kind = off, kind
+}
+
+func (s *statEntry) reset() { *s = statEntry{} }

--- a/pq/pq.go
+++ b/pq/pq.go
@@ -66,6 +66,8 @@ type Settings struct {
 	// Optional ACK callback. Will be use to notify number of events being successfully
 	// ACKed and pages being freed.
 	ACKed func(event, pages uint)
+
+	Observer Observer
 }
 
 // MakeRoot prepares the queue header (empty queue).

--- a/pq/pq.go
+++ b/pq/pq.go
@@ -225,7 +225,7 @@ func (q *Queue) Writer() (*Writer, error) {
 // The reader is not thread safe.
 func (q *Queue) Reader() *Reader {
 	if q.reader == nil {
-		q.reader = newReader(&q.accessor)
+		q.reader = newReader(q.settings.Observer, &q.accessor)
 	}
 	return q.reader
 }

--- a/pq/pq.go
+++ b/pq/pq.go
@@ -211,7 +211,7 @@ func (q *Queue) Writer() (*Writer, error) {
 
 	writeBuffer := q.settings.WriteBuffer
 	flushed := q.settings.Flushed
-	writer, err := newWriter(&q.accessor, q.pagePool, writeBuffer, tail, flushed)
+	writer, err := newWriter(&q.accessor, q.hdrOffset, q.settings.Observer, q.pagePool, writeBuffer, tail, flushed)
 	if err != nil {
 		return nil, q.accessor.errWrap(op, err)
 	}

--- a/pq/reader.go
+++ b/pq/reader.go
@@ -18,6 +18,8 @@
 package pq
 
 import (
+	"time"
+
 	"github.com/elastic/go-txfile"
 	"github.com/elastic/go-txfile/internal/invariant"
 )
@@ -29,12 +31,18 @@ type Reader struct {
 	active   bool
 
 	tx *txfile.Tx
+
+	hdrOff   uintptr
+	observer Observer
+	txStart  time.Time
+	stats    ReadStats
 }
 
 type readState struct {
-	id         uint64
-	endID      uint64 // id of next, yet unwritten event.
-	eventBytes int    // number of unread bytes in current event
+	id            uint64
+	endID         uint64 // id of next, yet unwritten event.
+	totEventBytes int    // number of total bytes in current event
+	eventBytes    int    // number of unread bytes in current event
 
 	cursor cursor
 }
@@ -44,7 +52,8 @@ func newReader(accessor *access) *Reader {
 		active:   true,
 		accessor: accessor,
 		state: readState{
-			eventBytes: -1,
+			eventBytes:    -1,
+			totEventBytes: -1,
 			cursor: cursor{
 				pageSize: accessor.PageSize(),
 			},
@@ -100,6 +109,8 @@ func (r *Reader) Begin() error {
 	}
 
 	r.tx = tx
+	r.txStart = time.Now()
+	r.stats = ReadStats{} // zero out last stats on begin
 	return nil
 }
 
@@ -110,6 +121,12 @@ func (r *Reader) Done() {
 	}
 
 	r.tx.Close()
+
+	r.stats.Duration = time.Since(r.txStart)
+	if o := r.observer; o != nil {
+		o.OnQueueRead(r.hdrOff, r.stats)
+	}
+
 	r.tx = nil
 }
 
@@ -187,6 +204,8 @@ func (r *Reader) Next() (int, error) {
 	tx := r.tx
 	cursor := makeTxCursor(tx, r.accessor, &r.state.cursor)
 
+	r.adoptEventStats()
+
 	// in event? Skip contents
 	if r.state.eventBytes > 0 {
 		err := cursor.Skip(r.state.eventBytes)
@@ -242,7 +261,34 @@ func (r *Reader) Next() (int, error) {
 	}
 	L := int(hdr.sz.Get())
 	r.state.eventBytes = L
+	r.state.totEventBytes = L
 	return L, nil
+}
+
+func (r *Reader) adoptEventStats() {
+	// update stats:
+	skipping := r.state.eventBytes > 0
+
+	if skipping {
+		r.stats.Skipped++
+		r.stats.BytesSkipped += uint(r.state.eventBytes)
+		r.stats.BytesTotal += uint(r.state.totEventBytes - r.state.eventBytes)
+	} else {
+		bytes := uint(r.state.totEventBytes)
+		r.stats.BytesTotal += bytes
+		if r.stats.Read == 0 {
+			r.stats.BytesMin = bytes
+			r.stats.BytesMax = bytes
+		} else {
+			if r.stats.BytesMin > bytes {
+				r.stats.BytesMin = bytes
+			}
+			if r.stats.BytesMax < bytes {
+				r.stats.BytesMax = bytes
+			}
+		}
+		r.stats.Read++
+	}
 }
 
 func (r *Reader) updateQueueState(tx *txfile.Tx) reason {

--- a/pq/testing_test.go
+++ b/pq/testing_test.go
@@ -127,6 +127,14 @@ func (q *testQueue) append(events ...string) {
 	}
 }
 
+func (q *testQueue) readWith(fn func(*Reader)) {
+	r := q.Reader()
+	q.t.FatalOnError(r.Begin())
+	defer r.Done()
+
+	fn(r)
+}
+
 // read reads up to n events from the queue.
 func (q *testQueue) read(n int) []string {
 	var out []string

--- a/pq/writer.go
+++ b/pq/writer.go
@@ -82,6 +82,9 @@ func newWriter(
 		pages = defaultMinPages
 	}
 
+	tracef("create queue writer with initBufferSize=%v, actualBufferSize=%v, pageSize=%v, pages=%v\n",
+		writeBuffer, pageSize*pages, pageSize, pages)
+
 	var tail *page
 	if end.page != 0 {
 		traceln("writer load endpage: ", end)


### PR DESCRIPTION
This change introduces a configurable observer listening for queue
operations: open, flush, read, ack. The observer will see read/write/allocation metrics based on recent operations.