### PR TITLE
Always require transaction on queue read

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Added `Observer` to txfile for collecting per transaction metrics. PR #23
 
 ### Changed
+- Queue reader requires explicit transaction start/stop calls. PR #27 
 
 ### Deprecated
 

--- a/pq/errkind_string.go
+++ b/pq/errkind_string.go
@@ -4,9 +4,9 @@ package pq
 
 import "strconv"
 
-const _ErrKind_name = "no errorfailed to initialize queueinvalid parameterinvalid page sizeinvalid queue configqueue is already closedreader is already closedwriter is already closedno queue rootqueue root is invalidunsupported queue versioninvalid ack on empty queuetoo many events ackedfailed to seek to next pagefailed to read page"
+const _ErrKind_name = "no errorfailed to initialize queueinvalid parameterinvalid page sizeinvalid queue configqueue is already closedreader is already closedwriter is already closedno queue rootqueue root is invalidunsupported queue versioninvalid ack on empty queuetoo many events ackedfailed to seek to next pagefailed to read pageno active transactionunexpected active transaction"
 
-var _ErrKind_index = [...]uint16{0, 8, 34, 51, 68, 88, 111, 135, 159, 172, 193, 218, 244, 265, 292, 311}
+var _ErrKind_index = [...]uint16{0, 8, 34, 51, 68, 88, 111, 135, 159, 172, 193, 218, 244, 265, 292, 311, 332, 361}
 
 func (i ErrKind) String() string {
 	if i < 0 || i >= ErrKind(len(_ErrKind_index)-1) {

--- a/pq/error.go
+++ b/pq/error.go
@@ -58,21 +58,23 @@ type errorCtx struct {
 //go:generate stringer -type=ErrKind -linecomment=true
 
 const (
-	NoError          ErrKind = iota // no error
-	InitFailed                      // failed to initialize queue
-	InvalidParam                    // invalid parameter
-	InvalidPageSize                 // invalid page size
-	InvalidConfig                   // invalid queue config
-	QueueClosed                     // queue is already closed
-	ReaderClosed                    // reader is already closed
-	WriterClosed                    // writer is already closed
-	NoQueueRoot                     // no queue root
-	InvalidQueueRoot                // queue root is invalid
-	QueueVersion                    // unsupported queue version
-	ACKEmptyQueue                   // invalid ack on empty queue
-	ACKTooMany                      // too many events acked
-	SeekFail                        // failed to seek to next page
-	ReadFail                        // failed to read page
+	NoError            ErrKind = iota // no error
+	InitFailed                        // failed to initialize queue
+	InvalidParam                      // invalid parameter
+	InvalidPageSize                   // invalid page size
+	InvalidConfig                     // invalid queue config
+	QueueClosed                       // queue is already closed
+	ReaderClosed                      // reader is already closed
+	WriterClosed                      // writer is already closed
+	NoQueueRoot                       // no queue root
+	InvalidQueueRoot                  // queue root is invalid
+	QueueVersion                      // unsupported queue version
+	ACKEmptyQueue                     // invalid ack on empty queue
+	ACKTooMany                        // too many events acked
+	SeekFail                          // failed to seek to next page
+	ReadFail                          // failed to read page
+	InactiveTx                        // no active transaction
+	UnexpectedActiveTx                // unexpected active transaction
 )
 
 // Error returns a user readable error message.

--- a/pq/testing_test.go
+++ b/pq/testing_test.go
@@ -102,6 +102,10 @@ func (q *testQueue) Close() {
 }
 
 func (q *testQueue) len() int {
+	reader := q.Reader()
+	q.t.FatalOnError(reader.Begin())
+	defer reader.Done()
+
 	i, err := q.Reader().Available()
 	q.t.NoError(err)
 	return int(i)
@@ -126,7 +130,7 @@ func (q *testQueue) read(n int) []string {
 	}
 
 	reader := q.Reader()
-	reader.Begin()
+	q.t.FatalOnError(reader.Begin())
 	defer reader.Done()
 
 	for n < 0 || len(out) < n {


### PR DESCRIPTION
so to simplfy code and API of the queue reader we will require a call to
Begin/Done when accessing contents in the file. Transaction will not be
generated implicitely anymore.