### PR TITLE
Configure sync mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 - Added `Observer` to txfile for collecting per transaction metrics. PR #23
+- Make file syncing configurable. PR #29
 
 ### Changed
 - Queue reader requires explicit transaction start/stop calls. PR #27 

--- a/file.go
+++ b/file.go
@@ -206,7 +206,7 @@ func newFile(
 		"page limit not configured on allocator")
 
 	// create asynchronous writer
-	f.writer.Init(file, f.allocator.pageSize)
+	f.writer.Init(file, f.allocator.pageSize, opts.Sync)
 	f.wg.Add(1)
 	go func() {
 		defer f.wg.Done()

--- a/file_test.go
+++ b/file_test.go
@@ -951,6 +951,10 @@ func setupTestFile(assert *assertions, opts Options) (*testFile, func()) {
 		opts.PageSize = 4096
 	}
 
+	if testing.Short() {
+		opts.Sync = SyncNone
+	}
+
 	ok := false
 	path, teardown := setupPath(assert, "")
 	defer cleanup.IfNot(&ok, teardown)

--- a/opts.go
+++ b/opts.go
@@ -22,6 +22,9 @@ type Options struct {
 	// Additional flags.
 	Flags Flag
 
+	// Configure file sync behavior
+	Sync SyncMode
+
 	// MaxSize sets the maximum file size in bytes. This should be a multiple of PageSize.
 	// If it's not a multiple of PageSize, the actual files maximum size is rounded downwards
 	// to the next multiple of PageSize.
@@ -65,6 +68,25 @@ const (
 	// shrink dynamically whenever pages are freed. Freed pages are returned via
 	// `Truncate`.
 	FlagUpdMaxSize
+)
+
+// SyncMode selects the file syncing behavior
+type SyncMode uint8
+
+const (
+	// SyncDefault lets the implementation choose the default syncing mode
+	SyncDefault SyncMode = iota
+
+	// SyncData prefers fdatasync if available. Still uses fsync (or similar) if
+	// implementation wants to enforce fsync.
+	SyncData
+
+	// SyncFull enforces fsync/or similar.
+	SyncFull
+
+	// SyncNone disable syncing. Do not use this in production environments, as
+	// this can easily cause file corruption.
+	SyncNone
 )
 
 // Validate checks if all fields in Options are consistent with the File implementation.

--- a/pq/testing_test.go
+++ b/pq/testing_test.go
@@ -19,6 +19,7 @@ package pq
 
 import (
 	"math/rand"
+	"testing"
 
 	"github.com/elastic/go-txfile"
 	"github.com/elastic/go-txfile/internal/cleanup"
@@ -46,6 +47,10 @@ func exactly(n int) testRange        { return testRange{n, n} }
 func between(min, max int) testRange { return testRange{min, max} }
 
 func setupQueue(t *mint.T, cfg config) (*testQueue, func()) {
+	if testing.Short() {
+		cfg.File.Sync = txfile.SyncNone
+	}
+
 	tf, teardown := txfiletest.SetupTestFile(t.T, cfg.File)
 
 	ok := false

--- a/write_test.go
+++ b/write_test.go
@@ -140,8 +140,11 @@ func TestFileWriter(t *testing.T) {
 			actual[i] = t
 			offsets[i] = off
 		}
-		assert.Equal(expectedOps, actual)
-		assert.Equal(expectedOffsets, offsets)
+
+		if assert.Equal(len(expectedOps), len(actual)) {
+			assert.Equal(expectedOps, actual)
+			assert.Equal(expectedOffsets, offsets)
+		}
 	})
 
 	assert.Run("ordered writes", func(assert *assertions) {
@@ -250,7 +253,7 @@ func TestFileWriter(t *testing.T) {
 
 func newTestWriter(to writable, pagesize uint) (*writer, func() error) {
 	w := &writer{}
-	w.Init(to, pagesize)
+	w.Init(to, pagesize, SyncDefault)
 
 	cw := makeCloseWait(1 * time.Second)
 	cw.Add(1)


### PR DESCRIPTION
This change makes the sync operation (fsync, fdatasync, none)
configurable.

If tests are run with `-short`, the `none` sync mode is configured. On
darwin syncing to disk is super slow. This brings down full test run
from 150s to <10s on my Laptop. Linux/Windows are relatively fast in
comparison.

Tests on CI still run with the default sync mode. This change mostly
addresses local testing.