### PR TITLE
Fix hang queue on open due to panic on atomic op

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,4 +42,3 @@ before_install:
 
 script: |
     go test -cover -v ./...
-

--- a/.travis.yml
+++ b/.travis.yml
@@ -42,3 +42,4 @@ before_install:
 
 script: |
     go test -cover -v ./...
+

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ### Removed
 
 ### Fixed
+- Panic on atomic operation (arm, x86-32) and File lock not released when panic occurs. PR #31
 
 ## [0.0.4]
 


### PR DESCRIPTION
The atomic transaction counter needs to be aligned to 64bit words, so to
not cause a panic on some architectures (arm or 32bit x86)

Unfortunately the file lock was not released when this panic occured,
making applications hang on startup.

We move the atomic to the top of the file and also ensure the file lock
is correctly released (using defer) if an error or panic occurs on
transaction begin.