### PR TITLE
Introduce mage and enable arm testing via docker+qemu

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,6 @@
 
 # Project-local glide cache, RE: https://github.com/Masterminds/glide/issues/736
 .glide/
+
+# build directory
+/build/

--- a/.travis.yml
+++ b/.travis.yml
@@ -48,8 +48,9 @@ jobs:
       script:
         - mage -v build:mage # cross compile mage target
         - mage -v build:test # cross compile tests
-        - file build/github.com/elastic/go-txfile/go-txfile github.com/elastic/go-txfile
-        - docker run -v $GOPATH/src:/go/src -w /go/src/github.com/elastic/go-txfile -e TEST_USE_BIN=1 --rm $DOCKER_IMAGE ./build/mage-linux-arm -v test
+        - file build/github.com/elastic/go-txfile/go-txfile
+        - docker run --rm -i -t $DOCKER_IMAGE go env
+        - docker run -v $GOPATH/src:/go/src -w /go/src/github.com/elastic/go-txfile -e TEST_USE_BIN=1 --rm -i -t $DOCKER_IMAGE ./build/mage-linux-arm -v test
 
 
 # Check we're testing the correct commit (Snippet from: https://github.com/travis-ci/travis-ci/issues/7459#issuecomment-287040521)

--- a/.travis.yml
+++ b/.travis.yml
@@ -48,6 +48,7 @@ jobs:
       script:
         - mage -v build:mage # cross compile mage target
         - mage -v build:test # cross compile tests
+        - file build/github.com/elastic/go-txfile/go-txfile github.com/elastic/go-txfile
         - docker run -v $GOPATH/src:/go/src -w /go/src/github.com/elastic/go-txfile -e TEST_USE_BIN=1 --rm $DOCKER_IMAGE ./build/mage-linux-arm -v test
 
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -42,8 +42,9 @@ before_install:
   - |
     # install mage
     go get -u -d github.com/magefile/mage
-    cd $GOPATH/src/github.com/magefile/mage
-    go run bootstrap.go
+    go run $GOPATH/src/github.com/magefile/mage/bootstrap.go
 
 script: |
+  pwd
+  go env
   mage test

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,12 +32,35 @@ jobs:
       go: $GO_CROSS_VERSION
       script: eval $GO_CHECK_CROSS_SCRIPT
 
-    # arm testing
-    - env:
+    # arm testing go1.10
+    - name: 32Bit ARM go1.10
+      env:
         - BUILD_OS=linux
         - BUILD_ARCH=arm
         - DOCKER_IMAGE=balenalib/revpi-core-3-alpine-golang:latest-edge-build
-      go: $GO_CROSS_VERSION
+      go: '1.10'
+      services:
+        - docker
+      before_install:
+        - docker pull $DOCKER_IMAGE
+        - docker run --rm --privileged multiarch/qemu-user-static:register --reset
+        - |
+          go get -u -d github.com/magefile/mage
+          (cd $GOPATH/src/github.com/magefile/mage; go run bootstrap.go)
+      script:
+        - mage -v build:mage # cross compile mage target
+        - mage -v build:test # cross compile tests
+        - file build/github.com/elastic/go-txfile/go-txfile
+        - docker run --rm -i -t balenalib/revpi-core-3-alpine-golang:latest-edge-build go env
+        - docker run -v $GOPATH/src:/go/src -w /go/src/github.com/elastic/go-txfile -e TEST_USE_BIN=1 --rm -i -t $DOCKER_IMAGE ./build/mage-linux-arm -v test
+
+    # arm testing go1.11
+    - name: 32Bit ARM go1.11
+      env:
+        - BUILD_OS=linux
+        - BUILD_ARCH=arm
+        - DOCKER_IMAGE=balenalib/revpi-core-3-alpine-golang:latest-edge-build
+      go: '1.11'
       services:
         - docker
       before_install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -42,6 +42,7 @@ jobs:
         - docker
       before_install:
         - docker pull $DOCKER_IMAGE
+        - docker run --rm --privileged multiarch/qemu-user-static:register --reset
         - |
           go get -u -d github.com/magefile/mage
           (cd $GOPATH/src/github.com/magefile/mage; go run bootstrap.go)

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,13 +22,16 @@ env:
 jobs:
   include:
     # try to cross compile to untested OSes
-    - env: TARGET=openbsd
+    - name: XBuild OpenBSD
+      env: TARGET=openbsd
       go: $GO_CROSS_VERSION
       script: eval $GO_CHECK_CROSS_SCRIPT
-    - env: TARGET=netbsd
+    - name: XBuild NetBSD
+      env: TARGET=netbsd
       go: $GO_CROSS_VERSION
       script: eval $GO_CHECK_CROSS_SCRIPT
-    - env: TARGET=freebsd
+    - name: XBuild FreeBSD
+      env: TARGET=freebsd
       go: $GO_CROSS_VERSION
       script: eval $GO_CHECK_CROSS_SCRIPT
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -42,7 +42,7 @@ before_install:
   - |
     # install mage
     go get -u -d github.com/magefile/mage
-    go run $GOPATH/src/github.com/magefile/mage/bootstrap.go
+    (cd $GOPATH/src/github.com/magefile/mage; go run bootstrap.go)
 
 script: |
   pwd

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,12 +33,14 @@ jobs:
       script: eval $GO_CHECK_CROSS_SCRIPT
 
     # arm testing go1.10
-    - name: 32Bit ARM go1.10
+    - name: 32Bit ARM
       env:
         - BUILD_OS=linux
         - BUILD_ARCH=arm
         - DOCKER_IMAGE=balenalib/revpi-core-3-alpine-golang:latest-edge-build
-      go: '1.10'
+      go:
+        - '1.10'
+        - '1.11'
       services:
         - docker
       before_install:
@@ -51,31 +53,31 @@ jobs:
         - mage -v build:mage # cross compile mage target
         - mage -v build:test # cross compile tests
         - file build/github.com/elastic/go-txfile/go-txfile
-        - docker run --rm -i -t balenalib/revpi-core-3-alpine-golang:latest-edge-build go env
+        - docker run --rm -i -t $DOCKER_IMAGE go env
         - docker run -v $GOPATH/src:/go/src -w /go/src/github.com/elastic/go-txfile -e TEST_USE_BIN=1 --rm -i -t $DOCKER_IMAGE ./build/mage-linux-arm -v test
 
-    # arm testing go1.11
-    - name: 32Bit ARM go1.11
-      env:
-        - BUILD_OS=linux
-        - BUILD_ARCH=arm
-        - DOCKER_IMAGE=balenalib/revpi-core-3-alpine-golang:latest-edge-build
-      go: '1.11'
-      services:
-        - docker
-      before_install:
-        - docker pull $DOCKER_IMAGE
-        - docker run --rm --privileged multiarch/qemu-user-static:register --reset
-        - |
-          go get -u -d github.com/magefile/mage
-          (cd $GOPATH/src/github.com/magefile/mage; go run bootstrap.go)
-      script:
-        - mage -v build:mage # cross compile mage target
-        - mage -v build:test # cross compile tests
-        - file build/github.com/elastic/go-txfile/go-txfile
-        - docker run --rm -i -t balenalib/revpi-core-3-alpine-golang:latest-edge-build go env
-        - docker run -v $GOPATH/src:/go/src -w /go/src/github.com/elastic/go-txfile -e TEST_USE_BIN=1 --rm -i -t $DOCKER_IMAGE ./build/mage-linux-arm -v test
-
+          #    # arm testing go1.11
+          #    - name: 32Bit ARM go1.11
+          #      env:
+          #        - BUILD_OS=linux
+          #        - BUILD_ARCH=arm
+          #        - DOCKER_IMAGE=balenalib/revpi-core-3-alpine-golang:latest-edge-build
+          #      go: '1.11'
+          #      services:
+          #        - docker
+          #      before_install:
+          #        - docker pull $DOCKER_IMAGE
+          #        - docker run --rm --privileged multiarch/qemu-user-static:register --reset
+          #        - |
+          #          go get -u -d github.com/magefile/mage
+          #          (cd $GOPATH/src/github.com/magefile/mage; go run bootstrap.go)
+          #      script:
+          #        - mage -v build:mage # cross compile mage target
+          #        - mage -v build:test # cross compile tests
+          #        - file build/github.com/elastic/go-txfile/go-txfile
+          #        - docker run --rm -i -t balenalib/revpi-core-3-alpine-golang:latest-edge-build go env
+          #        - docker run -v $GOPATH/src:/go/src -w /go/src/github.com/elastic/go-txfile -e TEST_USE_BIN=1 --rm -i -t $DOCKER_IMAGE ./build/mage-linux-arm -v test
+          #
 
 # Check we're testing the correct commit (Snippet from: https://github.com/travis-ci/travis-ci/issues/7459#issuecomment-287040521)
 before_install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,15 +32,12 @@ jobs:
       go: $GO_CROSS_VERSION
       script: eval $GO_CHECK_CROSS_SCRIPT
 
-    # arm testing go1.10
-    - name: 32Bit ARM
+    - name: 32Bit ARM go1.10
       env:
         - BUILD_OS=linux
         - BUILD_ARCH=arm
         - DOCKER_IMAGE=balenalib/revpi-core-3-alpine-golang:latest-edge-build
-      go:
-        - '1.10'
-        - '1.11'
+      go: '1.10'
       services:
         - docker
       before_install:
@@ -56,28 +53,27 @@ jobs:
         - docker run --rm -i -t $DOCKER_IMAGE go env
         - docker run -v $GOPATH/src:/go/src -w /go/src/github.com/elastic/go-txfile -e TEST_USE_BIN=1 --rm -i -t $DOCKER_IMAGE ./build/mage-linux-arm -v test
 
-          #    # arm testing go1.11
-          #    - name: 32Bit ARM go1.11
-          #      env:
-          #        - BUILD_OS=linux
-          #        - BUILD_ARCH=arm
-          #        - DOCKER_IMAGE=balenalib/revpi-core-3-alpine-golang:latest-edge-build
-          #      go: '1.11'
-          #      services:
-          #        - docker
-          #      before_install:
-          #        - docker pull $DOCKER_IMAGE
-          #        - docker run --rm --privileged multiarch/qemu-user-static:register --reset
-          #        - |
-          #          go get -u -d github.com/magefile/mage
-          #          (cd $GOPATH/src/github.com/magefile/mage; go run bootstrap.go)
-          #      script:
-          #        - mage -v build:mage # cross compile mage target
-          #        - mage -v build:test # cross compile tests
-          #        - file build/github.com/elastic/go-txfile/go-txfile
-          #        - docker run --rm -i -t balenalib/revpi-core-3-alpine-golang:latest-edge-build go env
-          #        - docker run -v $GOPATH/src:/go/src -w /go/src/github.com/elastic/go-txfile -e TEST_USE_BIN=1 --rm -i -t $DOCKER_IMAGE ./build/mage-linux-arm -v test
-          #
+    - name: 32Bit ARM go1.11
+      env:
+        - BUILD_OS=linux
+        - BUILD_ARCH=arm
+        - DOCKER_IMAGE=balenalib/revpi-core-3-alpine-golang:latest-edge-build
+      go: '1.11'
+      services:
+        - docker
+      before_install:
+        - docker pull $DOCKER_IMAGE
+        - docker run --rm --privileged multiarch/qemu-user-static:register --reset
+        - |
+          go get -u -d github.com/magefile/mage
+          (cd $GOPATH/src/github.com/magefile/mage; go run bootstrap.go)
+      script:
+        - mage -v build:mage # cross compile mage target
+        - mage -v build:test # cross compile tests
+        - file build/github.com/elastic/go-txfile/go-txfile
+        - docker run --rm -i -t balenalib/revpi-core-3-alpine-golang:latest-edge-build go env
+        - docker run -v $GOPATH/src:/go/src -w /go/src/github.com/elastic/go-txfile -e TEST_USE_BIN=1 --rm -i -t $DOCKER_IMAGE ./build/mage-linux-arm -v test
+
 
 # Check we're testing the correct commit (Snippet from: https://github.com/travis-ci/travis-ci/issues/7459#issuecomment-287040521)
 before_install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,47 +33,28 @@ jobs:
       script: eval $GO_CHECK_CROSS_SCRIPT
 
     - name: 32Bit ARM go1.10
-      env:
-        - BUILD_OS=linux
-        - BUILD_ARCH=arm
-        - DOCKER_IMAGE=balenalib/revpi-core-3-alpine-golang:latest-edge-build
+      env: [BUILD_OS=linux, BUILD_ARCH=arm]
       go: '1.10'
-      services:
-        - docker
+      services: [docker]
       before_install:
-        - docker pull $DOCKER_IMAGE
         - docker run --rm --privileged multiarch/qemu-user-static:register --reset
         - |
           go get -u -d github.com/magefile/mage
           (cd $GOPATH/src/github.com/magefile/mage; go run bootstrap.go)
       script:
-        - mage -v build:mage # cross compile mage target
-        - mage -v build:test # cross compile tests
-        - file build/github.com/elastic/go-txfile/go-txfile
-        - docker run --rm -i -t $DOCKER_IMAGE go env
-        - docker run -v $GOPATH/src:/go/src -w /go/src/github.com/elastic/go-txfile -e TEST_USE_BIN=1 --rm -i -t $DOCKER_IMAGE ./build/mage-linux-arm -v test
+        - mage -v build:test
 
     - name: 32Bit ARM go1.11
-      env:
-        - BUILD_OS=linux
-        - BUILD_ARCH=arm
-        - DOCKER_IMAGE=balenalib/revpi-core-3-alpine-golang:latest-edge-build
+      env: [BUILD_OS=linux, BUILD_ARCH=arm]
       go: '1.11'
-      services:
-        - docker
+      services: [docker]
       before_install:
-        - docker pull $DOCKER_IMAGE
         - docker run --rm --privileged multiarch/qemu-user-static:register --reset
         - |
           go get -u -d github.com/magefile/mage
           (cd $GOPATH/src/github.com/magefile/mage; go run bootstrap.go)
       script:
-        - mage -v build:mage # cross compile mage target
-        - mage -v build:test # cross compile tests
-        - file build/github.com/elastic/go-txfile/go-txfile
-        - docker run --rm -i -t balenalib/revpi-core-3-alpine-golang:latest-edge-build go env
-        - docker run -v $GOPATH/src:/go/src -w /go/src/github.com/elastic/go-txfile -e TEST_USE_BIN=1 --rm -i -t $DOCKER_IMAGE ./build/mage-linux-arm -v test
-
+        - mage -v build:test
 
 # Check we're testing the correct commit (Snippet from: https://github.com/travis-ci/travis-ci/issues/7459#issuecomment-287040521)
 before_install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -45,7 +45,7 @@ jobs:
           go get -u -d github.com/magefile/mage
           (cd $GOPATH/src/github.com/magefile/mage; go run bootstrap.go)
       script:
-        - mage -v build:test
+        - mage -v test
 
     - name: 32Bit ARM go1.11
       env: [BUILD_OS=linux, BUILD_ARCH=arm]
@@ -57,7 +57,7 @@ jobs:
           go get -u -d github.com/magefile/mage
           (cd $GOPATH/src/github.com/magefile/mage; go run bootstrap.go)
       script:
-        - mage -v build:test
+        - mage -v test
 
 # Check we're testing the correct commit (Snippet from: https://github.com/travis-ci/travis-ci/issues/7459#issuecomment-287040521)
 before_install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -49,7 +49,7 @@ jobs:
         - mage -v build:mage # cross compile mage target
         - mage -v build:test # cross compile tests
         - file build/github.com/elastic/go-txfile/go-txfile
-        - docker run --rm -i -t $DOCKER_IMAGE go env
+        - docker run --rm -i -t balenalib/revpi-core-3-alpine-golang:latest-edge-build go env
         - docker run -v $GOPATH/src:/go/src -w /go/src/github.com/elastic/go-txfile -e TEST_USE_BIN=1 --rm -i -t $DOCKER_IMAGE ./build/mage-linux-arm -v test
 
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,6 +32,22 @@ jobs:
       go: $GO_CROSS_VERSION
       script: eval $GO_CHECK_CROSS_SCRIPT
 
+    # arm testing
+    - env:
+        - BUILD_OS=linux
+        - BUILD_ARCH=arm
+        - DOCKER_IMAGE=balenalib/revpi-core-3-alpine-golang:latest-edge-build
+      go: $GO_CROSS_VERSION
+      services:
+        - docker
+      before_install:
+        - docker pull $DOCKER_IMAGE
+      script:
+        - mage build:mage # cross compile mage target
+        - mage build:test # cross compile tests
+        - docker run -v $GOPATH/src:/go/src -w /go/src/github.com/elastic/go-txfile -e TEST_USE_BIN=1 --rm $DOCKER_IMAGE  ./build/mage-linux-arm test
+
+
 # Check we're testing the correct commit (Snippet from: https://github.com/travis-ci/travis-ci/issues/7459#issuecomment-287040521)
 before_install:
   - |

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,6 +39,11 @@ before_install:
       echo "Commit $(git rev-parse HEAD) doesn't match expected commit $TRAVIS_COMMIT"
       exit 1
     fi
+  - |
+    # install mage
+    go get -u -d github.com/magefile/mage
+    cd $GOPATH/src/github.com/magefile/mage
+    go run bootstrap.go
 
 script: |
-    go test -cover -v ./...
+  mage test

--- a/.travis.yml
+++ b/.travis.yml
@@ -42,10 +42,13 @@ jobs:
         - docker
       before_install:
         - docker pull $DOCKER_IMAGE
+        - |
+          go get -u -d github.com/magefile/mage
+          (cd $GOPATH/src/github.com/magefile/mage; go run bootstrap.go)
       script:
-        - mage build:mage # cross compile mage target
-        - mage build:test # cross compile tests
-        - docker run -v $GOPATH/src:/go/src -w /go/src/github.com/elastic/go-txfile -e TEST_USE_BIN=1 --rm $DOCKER_IMAGE  ./build/mage-linux-arm test
+        - mage -v build:mage # cross compile mage target
+        - mage -v build:test # cross compile tests
+        - docker run -v $GOPATH/src:/go/src -w /go/src/github.com/elastic/go-txfile -e TEST_USE_BIN=1 --rm $DOCKER_IMAGE ./build/mage-linux-arm -v test
 
 
 # Check we're testing the correct commit (Snippet from: https://github.com/travis-ci/travis-ci/issues/7459#issuecomment-287040521)
@@ -60,7 +63,6 @@ before_install:
     go get -u -d github.com/magefile/mage
     (cd $GOPATH/src/github.com/magefile/mage; go run bootstrap.go)
 
-script: |
-  pwd
-  go env
-  mage test
+script:
+- go env
+- mage -v test

--- a/dev-tools/lib/mage/gotool/go.go
+++ b/dev-tools/lib/mage/gotool/go.go
@@ -26,6 +26,8 @@ import (
 	"github.com/magefile/mage/sh"
 )
 
+// Args holds parameters, environment variables and flag information used to
+// pass to the go tool.
 type Args struct {
 	extra map[string]string // extra flags one can pass to the command
 	env   map[string]string
@@ -33,20 +35,25 @@ type Args struct {
 	pos   []string
 }
 
+// ArgOpt is a functional option adding info to Args once executed.
 type ArgOpt func(args *Args)
 
 type goTest func(opts ...ArgOpt) error
 
+// Test runs `go test` and provides optionals for adding command line arguments.
 var Test goTest = runGoTest
 
+// ListProjectPackages lists all packages in the current project
 func ListProjectPackages() ([]string, error) {
 	return ListPackages("./...")
 }
 
+// ListPackages calls `go list` for every package spec given.
 func ListPackages(pkgs ...string) ([]string, error) {
 	return getLines(callGo(nil, "list", pkgs...))
 }
 
+// ListTestFiles lists all go and cgo test files available in a package.
 func ListTestFiles(pkg string) ([]string, error) {
 	const tmpl = `{{ range .TestGoFiles }}{{ printf "%s\n" . }}{{ end }}` +
 		`{{ range .XTestGoFiles }}{{ printf "%s\n" . }}{{ end }}`
@@ -54,6 +61,7 @@ func ListTestFiles(pkg string) ([]string, error) {
 	return getLines(callGo(nil, "list", "-f", tmpl, pkg))
 }
 
+// HasTests returns true if the given package contains test files.
 func HasTests(pkg string) (bool, error) {
 	files, err := ListTestFiles(pkg)
 	if err != nil {
@@ -199,6 +207,7 @@ func buildArgs(opts []ArgOpt) *Args {
 	return a
 }
 
+// Extra sets a special k/v pair to be interpreted by the execution function.
 func (a *Args) Extra(k, v string) {
 	if a.extra == nil {
 		a.extra = map[string]string{}
@@ -206,6 +215,7 @@ func (a *Args) Extra(k, v string) {
 	a.extra[k] = v
 }
 
+// Val returns a special functions value for a given key.
 func (a *Args) Val(k string) string {
 	if a.extra == nil {
 		return ""
@@ -213,6 +223,7 @@ func (a *Args) Val(k string) string {
 	return a.extra[k]
 }
 
+// Env sets an environmant variable to be passed to the child process on exec.
 func (a *Args) Env(k, v string) {
 	if a.env == nil {
 		a.env = map[string]string{}
@@ -220,6 +231,7 @@ func (a *Args) Env(k, v string) {
 	a.env[k] = v
 }
 
+// Flag adds a flag to be passed to the child process on exec.
 func (a *Args) Flag(flag, value string) {
 	if a.flags == nil {
 		a.flags = map[string]string{}
@@ -227,6 +239,7 @@ func (a *Args) Flag(flag, value string) {
 	a.flags[flag] = value
 }
 
+// Add adds a positional argument to be passed to the child process on exec.
 func (a *Args) Add(p string) {
 	a.pos = append(a.pos, p)
 }

--- a/dev-tools/lib/mage/gotool/go.go
+++ b/dev-tools/lib/mage/gotool/go.go
@@ -18,7 +18,6 @@
 package gotool
 
 import (
-	"fmt"
 	"os"
 	"strings"
 
@@ -67,8 +66,6 @@ func HasTests(pkg string) (bool, error) {
 	if err != nil {
 		return false, err
 	}
-
-	fmt.Println("test files: ", len(files), files)
 	return len(files) > 0, nil
 }
 

--- a/dev-tools/lib/mage/gotool/go.go
+++ b/dev-tools/lib/mage/gotool/go.go
@@ -1,0 +1,211 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package gotool
+
+import (
+	"os"
+	"strings"
+
+	"github.com/magefile/mage/mg"
+	"github.com/magefile/mage/sh"
+)
+
+type Args struct {
+	extra map[string]string // extra flags one can pass to the command
+	env   map[string]string
+	flags map[string]string
+	pos   []string
+}
+
+type ArgOpt func(args *Args)
+
+type goTest func(opts ...ArgOpt) error
+
+var Test goTest = runGoTest
+
+func ListProjectPackages() ([]string, error) {
+	return ListPackages("./...")
+}
+
+func ListPackages(pkgs ...string) ([]string, error) {
+	out, err := callGo(nil, "list", pkgs)
+	if err != nil {
+		return nil, err
+	}
+
+	lines := strings.Split(out, "\n")
+	for i := range lines {
+		lines[i] = strings.TrimSpace(lines[i])
+	}
+	return lines, nil
+}
+
+func (goTest) WithCoverage(to string) ArgOpt {
+	return combine(flagArg("-cover", ""), flagArgIf("-test.coverprofile", to))
+}
+func (goTest) Use(bin string) ArgOpt      { return extraArgIf("use", bin) }
+func (goTest) OS(os string) ArgOpt        { return envArgIf("GOOS", os) }
+func (goTest) ARCH(arch string) ArgOpt    { return envArgIf("GOARCH", arch) }
+func (goTest) Create() ArgOpt             { return flagArg("-c", "") }
+func (goTest) Out(path string) ArgOpt     { return flagArg("-o", path) }
+func (goTest) Package(path string) ArgOpt { return posArg(path) }
+func (goTest) Verbose() ArgOpt            { return flagArg("-test.v", "") }
+func runGoTest(opts ...ArgOpt) error {
+	args := buildArgs(opts)
+	if bin := args.Val("use"); bin != "" {
+		flags := map[string]string{}
+		for k, v := range args.flags {
+			if strings.HasPrefix(k, "-test.") {
+				flags[k] = v
+			}
+		}
+
+		useArgs := &Args{}
+		*useArgs = *args
+		useArgs.flags = flags
+
+		_, err := sh.Exec(useArgs.env, os.Stdout, os.Stderr, bin, useArgs.build()...)
+		return err
+	}
+
+	return runVGo("test", args)
+}
+
+func callGo(env map[string]string, cmd string, opts []string) (string, error) {
+	args := []string{cmd}
+	args = append(args, opts...)
+	return sh.OutputWith(env, mg.GoCmd(), args...)
+}
+
+func runVGo(cmd string, args *Args) error {
+	return execGoWith(func(env map[string]string, cmd string, args ...string) error {
+		_, err := sh.Exec(env, os.Stdout, os.Stderr, cmd, args...)
+		return err
+	}, cmd, args)
+}
+
+func runGo(cmd string, args *Args) error {
+	return execGoWith(sh.RunWith, cmd, args)
+}
+
+func execGoWith(
+	fn func(map[string]string, string, ...string) error,
+	cmd string, args *Args,
+) error {
+	cliArgs := []string{cmd}
+	cliArgs = append(cliArgs, args.build()...)
+	return fn(args.env, mg.GoCmd(), cliArgs...)
+}
+
+func posArg(value string) ArgOpt {
+	return func(a *Args) { a.Add(value) }
+}
+
+func extraArg(k, v string) ArgOpt {
+	return func(a *Args) { a.Extra(k, v) }
+}
+
+func extraArgIf(k, v string) ArgOpt {
+	if v == "" {
+		return nil
+	}
+	return extraArg(k, v)
+}
+
+func envArg(k, v string) ArgOpt {
+	return func(a *Args) { a.Env(k, v) }
+}
+
+func envArgIf(k, v string) ArgOpt {
+	if v == "" {
+		return nil
+	}
+	return envArg(k, v)
+}
+
+func flagArg(flag, value string) ArgOpt {
+	return func(a *Args) { a.Flag(flag, value) }
+}
+
+func flagArgIf(flag, value string) ArgOpt {
+	if value == "" {
+		return nil
+	}
+	return flagArg(flag, value)
+}
+
+func combine(opts ...ArgOpt) ArgOpt {
+	return func(a *Args) {
+		for _, opt := range opts {
+			if opt != nil {
+				opt(a)
+			}
+		}
+	}
+}
+
+func buildArgs(opts []ArgOpt) *Args {
+	a := &Args{}
+	combine(opts...)(a)
+	return a
+}
+
+func (a *Args) Extra(k, v string) {
+	if a.extra == nil {
+		a.extra = map[string]string{}
+	}
+	a.extra[k] = v
+}
+
+func (a *Args) Val(k string) string {
+	if a.extra == nil {
+		return ""
+	}
+	return a.extra[k]
+}
+
+func (a *Args) Env(k, v string) {
+	if a.env == nil {
+		a.env = map[string]string{}
+	}
+	a.env[k] = v
+}
+
+func (a *Args) Flag(flag, value string) {
+	if a.flags == nil {
+		a.flags = map[string]string{}
+	}
+	a.flags[flag] = value
+}
+
+func (a *Args) Add(p string) {
+	a.pos = append(a.pos, p)
+}
+
+func (a *Args) build() []string {
+	args := make([]string, 0, 2*len(a.flags)+len(a.pos))
+	for k, v := range a.flags {
+		args = append(args, k)
+		if v != "" {
+			args = append(args, v)
+		}
+	}
+
+	args = append(args, a.pos...)
+	return args
+}

--- a/dev-tools/lib/mage/mgenv/mgenv.go
+++ b/dev-tools/lib/mage/mgenv/mgenv.go
@@ -24,6 +24,7 @@ import (
 	"strconv"
 )
 
+// Var holds an environment variables name, default value and doc string.
 type Var struct {
 	name  string
 	other string
@@ -45,30 +46,43 @@ func makeVar(name, other, doc string) Var {
 	return v
 }
 
+// Keys returns the keys of registered environment variables. The keys returned
+// are sorted.
+// Note: The returned slice must not be changed or appended to.
 func Keys() []string {
 	return envKeys
 }
 
+// Find returns a registered Var by name.
 func Find(name string) (Var, bool) {
 	v, ok := envVars[name]
 	return v, ok
 }
 
+// String registers an environment variable and reads the current contents.
 func String(name, other, doc string) string {
 	v := makeVar(name, other, doc)
 	return v.Get()
 }
 
+// Bool registers an environment variable and interprets the current variable as bool.
 func Bool(name string, other bool, doc string) bool {
 	v := makeVar(name, fmt.Sprint(other), doc)
 	b, err := strconv.ParseBool(v.Get())
 	return err == nil && b
 }
 
-func (v Var) Name() string    { return v.name }
-func (v Var) Default() string { return v.other }
-func (v Var) Doc() string     { return v.doc }
+// Name returns the environment variables name
+func (v Var) Name() string { return v.name }
 
+// Default returns the environment variables default value as string.
+func (v Var) Default() string { return v.other }
+
+// Doc returns the doc-string.
+func (v Var) Doc() string { return v.doc }
+
+// Get reads an environment variable. Get returns the default value if the
+// variable is not present or empty.
 func (v Var) Get() string {
 	val := os.Getenv(v.name)
 	if val == "" {

--- a/dev-tools/lib/mage/mgenv/mgenv.go
+++ b/dev-tools/lib/mage/mgenv/mgenv.go
@@ -1,0 +1,78 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package mgenv
+
+import (
+	"fmt"
+	"os"
+	"sort"
+	"strconv"
+)
+
+type Var struct {
+	name  string
+	other string
+	doc   string
+}
+
+var envVars = map[string]Var{}
+var envKeys []string
+
+func makeVar(name, other, doc string) Var {
+	if v, exists := envVars[name]; exists {
+		return v
+	}
+
+	v := Var{name, other, doc}
+	envVars[name] = v
+	envKeys = append(envKeys, name)
+	sort.Strings(envKeys)
+	return v
+}
+
+func Keys() []string {
+	return envKeys
+}
+
+func Find(name string) (Var, bool) {
+	v, ok := envVars[name]
+	return v, ok
+}
+
+func String(name, other, doc string) string {
+	v := makeVar(name, other, doc)
+	return v.Get()
+}
+
+func Bool(name string, other bool, doc string) bool {
+	v := makeVar(name, fmt.Sprint(other), doc)
+	b, err := strconv.ParseBool(v.Get())
+	return err == nil && b
+}
+
+func (v Var) Name() string    { return v.name }
+func (v Var) Default() string { return v.other }
+func (v Var) Doc() string     { return v.doc }
+
+func (v Var) Get() string {
+	val := os.Getenv(v.name)
+	if val == "" {
+		return v.Default()
+	}
+	return val
+}

--- a/dev-tools/lib/mage/mgenv/mgenv.go
+++ b/dev-tools/lib/mage/mgenv/mgenv.go
@@ -46,6 +46,16 @@ func makeVar(name, other, doc string) Var {
 	return v
 }
 
+// MakeEnv builds a dictionary of defined environment variables, such that
+// these can be passed to other processes (e.g. providers)
+func MakeEnv() map[string]string {
+	m := make(map[string]string, len(envVars))
+	for k, v := range envVars {
+		m[k] = v.Get()
+	}
+	return m
+}
+
 // Keys returns the keys of registered environment variables. The keys returned
 // are sorted.
 // Note: The returned slice must not be changed or appended to.

--- a/dev-tools/lib/mage/xbuild/docker.go
+++ b/dev-tools/lib/mage/xbuild/docker.go
@@ -1,0 +1,70 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package xbuild
+
+import (
+	"fmt"
+
+	"github.com/magefile/mage/sh"
+)
+
+type DockerImage struct {
+	Image   string
+	Workdir string
+	Volumes map[string]string
+	Env     map[string]string
+}
+
+func (p DockerImage) Build() error {
+	return sh.Run("docker", "pull", p.Image)
+}
+
+func (p DockerImage) Run(env map[string]string, cmdAndArgs ...string) error {
+	spec := []string{"run", "--rm", "-i", "-t"}
+	for k, v := range mergeEnv(p.Env, env) {
+		spec = append(spec, "-e", fmt.Sprintf("%v=%v", k, v))
+	}
+	for k, v := range p.Volumes {
+		spec = append(spec, "-v", fmt.Sprintf("%v:%v", k, v))
+	}
+	if w := p.Workdir; w != "" {
+		spec = append(spec, "-w", w)
+	}
+
+	spec = append(spec, p.Image)
+	for _, v := range cmdAndArgs {
+		if v != "" {
+			spec = append(spec, v)
+		}
+	}
+
+	return sh.RunV("docker", spec...)
+}
+
+func mergeEnv(a, b map[string]string) map[string]string {
+	merged := make(map[string]string, len(a)+len(b))
+	copyEnv(merged, a)
+	copyEnv(merged, b)
+	return merged
+}
+
+func copyEnv(to, from map[string]string) {
+	for k, v := range from {
+		to[k] = v
+	}
+}

--- a/dev-tools/lib/mage/xbuild/docker.go
+++ b/dev-tools/lib/mage/xbuild/docker.go
@@ -23,6 +23,7 @@ import (
 	"github.com/magefile/mage/sh"
 )
 
+// DockerImage provides based on downloadable docker images.
 type DockerImage struct {
 	Image   string
 	Workdir string
@@ -30,10 +31,13 @@ type DockerImage struct {
 	Env     map[string]string
 }
 
+// Build pulls the required image.
 func (p DockerImage) Build() error {
 	return sh.Run("docker", "pull", p.Image)
 }
 
+// Run executes the command in a temporary docker container. The container is
+// deleted after its execution.
 func (p DockerImage) Run(env map[string]string, cmdAndArgs ...string) error {
 	spec := []string{"run", "--rm", "-i", "-t"}
 	for k, v := range mergeEnv(p.Env, env) {

--- a/dev-tools/lib/mage/xbuild/xbuild.go
+++ b/dev-tools/lib/mage/xbuild/xbuild.go
@@ -1,0 +1,60 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package xbuild
+
+import (
+	"fmt"
+
+	"github.com/magefile/mage/mg"
+)
+
+type Regsitry struct {
+	table map[OSArch]Provider
+}
+
+type Provider interface {
+	Build() error
+	Run(env map[string]string, cmdAndArgs ...string) error
+}
+
+type OSArch struct {
+	OS   string
+	Arch string
+}
+
+func NewRegistry(tbl map[OSArch]Provider) *Regsitry {
+	return &Regsitry{tbl}
+}
+
+func (r *Regsitry) Find(os, arch string) (Provider, error) {
+	p := r.table[OSArch{os, arch}]
+	if p == nil {
+		return nil, fmt.Errorf("No provider for %v:%v defined", os, arch)
+	}
+	return p, nil
+}
+
+func (r *Regsitry) With(os, arch string, fn func(Provider) error) error {
+	p, err := r.Find(os, arch)
+	if err != nil {
+		return err
+	}
+
+	mg.Deps(p.Build)
+	return fn(p)
+}

--- a/file_test.go
+++ b/file_test.go
@@ -82,7 +82,8 @@ func TestTxFile(t *testing.T) {
 			title := fmt.Sprintf("min=%v,max=%v,expected=%v", min, max, expected)
 
 			assert.Run(title, func(assert *assertions) {
-				if expected > uint64(maxUint) {
+				fmt.Printf("maxUint: %v, expected: %v\n", maxUint, expected)
+				if expected > uint64(maxMmapSize) {
 					assert.Skip("unsatisfyable tests on 32bit system")
 				}
 

--- a/magefile.go
+++ b/magefile.go
@@ -1,0 +1,221 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//+build mage
+
+package main
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path"
+	"path/filepath"
+	"runtime"
+	"sort"
+	"strconv"
+
+	"github.com/joeshaw/multierror"
+	"github.com/magefile/mage/mg"
+	"github.com/magefile/mage/sh"
+
+	"github.com/elastic/go-txfile/dev-tools/lib/mage/gotool"
+)
+
+type Check mg.Namespace
+type Prepare mg.Namespace
+type Build mg.Namespace
+type Info mg.Namespace
+
+const buildHome = "build"
+
+type envVar struct{ name, other, doc string }
+
+// environment variables
+var (
+	envBuildOS    = defEnv("BUILD_OS", "", "(string) set compiler target GOOS")
+	envBuildArch  = defEnv("BUILD_ARCH", "", "(string) set compiler target GOARCH")
+	envTestUseBin = defEnv("TEST_USE_BIN", "", "(bool) reuse prebuild test binary when running tests")
+)
+
+var envVars = map[string]*envVar{}
+
+func defEnv(name, value, doc string) *envVar {
+	e := &envVar{name: name, other: value, doc: doc}
+	if _, exists := envVars[name]; exists {
+		panic(fmt.Errorf("env variable '%v' already registered", name))
+	}
+	envVars[name] = e
+	return e
+}
+
+func (e *envVar) get() string {
+	v := os.Getenv(e.name)
+	if v == "" {
+		return e.other
+	}
+	return v
+}
+
+// targets
+
+func (Info) Env() {
+	keys := make([]string, 0, len(envVars))
+	for k := range envVars {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
+	for _, k := range keys {
+		v := envVars[k]
+		fmt.Printf("%v: %v\n", k, v.doc)
+	}
+}
+
+func (Check) Lint() error {
+	return errors.New("TODO: implement me")
+}
+
+func (Prepare) Dirs() error {
+	return mkdir("build")
+}
+
+func (Build) Mage() error {
+	mg.Deps(Prepare.Dirs)
+
+	goos := envDefault(envBuildOS, runtime.GOOS)
+	goarch := envDefault(envBuildArch, runtime.GOARCH)
+	out := filepath.Join(buildHome, fmt.Sprintf("mage-%v-%v", goos, goarch))
+	return sh.Run("mage", "-f", "-goos="+goos, "-goarch="+goarch, "-compile", out)
+}
+
+func (Build) Test() error {
+	mg.Deps(Prepare.Dirs)
+
+	return withList(gotool.ListProjectPackages, each, func(pkg string) error {
+		tst := gotool.Test
+		return tst(
+			tst.OS(env(envBuildOS)),
+			tst.ARCH(env(envBuildArch)),
+			tst.Create(),
+			tst.WithCoverage(""),
+			tst.Out(path.Join(buildHome, pkg, path.Base(pkg))),
+			tst.Package(pkg),
+		)
+	})
+}
+
+func Test() error {
+	mg.Deps(Prepare.Dirs)
+
+	return withList(gotool.ListProjectPackages, each, func(pkg string) error {
+		tst := gotool.Test
+		fmt.Println("Test:", pkg)
+		bin := path.Join(buildHome, pkg, path.Base(pkg))
+		return tst(
+			tst.Use(useIf(bin, existsFile(bin) && envBool(envTestUseBin))),
+			tst.WithCoverage(path.Join(buildHome, pkg, "cover.out")),
+			tst.Out(bin),
+			tst.Package(pkg),
+			tst.Verbose(),
+		)
+	})
+}
+
+func Clean() error {
+	return sh.Rm(buildHome)
+}
+
+// helpers
+
+func withList(
+	gen func() ([]string, error),
+	mode func(...func() error) error,
+	fn func(string) error,
+) error {
+	list, err := gen()
+	if err != nil {
+		return err
+	}
+
+	ops := make([]func() error, len(list))
+	for i, v := range list {
+		v := v
+		ops[i] = func() error { return fn(v) }
+	}
+
+	return mode(ops...)
+}
+
+func useIf(s string, b bool) string {
+	if b {
+		return s
+	}
+	return ""
+}
+
+func existsFile(path string) bool {
+	fi, err := os.Stat(path)
+	return err == nil && fi.Mode().IsRegular()
+}
+
+func env(ev *envVar) string { return ev.get() }
+
+func envDefault(ev *envVar, other string) string {
+	v := env(ev)
+	if v == "" {
+		return other
+	}
+	return v
+}
+
+func envBool(ev *envVar) bool {
+	b, err := strconv.ParseBool(env(ev))
+	return err == nil && b
+}
+
+func mkdirs(paths ...string) error {
+	for _, p := range paths {
+		if err := mkdir(p); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func mkdir(path string) error {
+	return os.MkdirAll(path, os.ModeDir|0700)
+}
+
+func each(ops ...func() error) error {
+	var errs multierror.Errors
+	for _, op := range ops {
+		if err := op(); err != nil {
+			errs = append(errs, err)
+		}
+	}
+	return errs.Err()
+}
+
+func and(ops ...func() error) error {
+	for _, op := range ops {
+		if err := op(); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/magefile.go
+++ b/magefile.go
@@ -104,7 +104,13 @@ func Test() error {
 
 		tst := gotool.Test
 		fmt.Println("Test:", pkg)
-		bin := path.Join(buildHome, pkg, path.Base(pkg))
+
+		home := path.Join(buildHome, pkg)
+		if err := mkdir(home); err != nil {
+			return err
+		}
+
+		bin := path.Join(home, path.Base(pkg))
 		return tst(
 			tst.Use(useIf(bin, existsFile(bin) && envTestUseBin)),
 			tst.WithCoverage(path.Join(buildHome, pkg, "cover.out")),

--- a/magefile.go
+++ b/magefile.go
@@ -35,10 +35,17 @@ import (
 	"github.com/elastic/go-txfile/dev-tools/lib/mage/mgenv"
 )
 
-type Check mg.Namespace
-type Prepare mg.Namespace
-type Build mg.Namespace
+// Info namespace is used to print additional docs, help messages, and other info.
 type Info mg.Namespace
+
+// Prepare namespace is used to prepare/download/build common depenendencies for other tasks to run.
+type Prepare mg.Namespace
+
+// Check runs pre-build checks on the environment and source code. (e.g. linters)
+type Check mg.Namespace
+
+// Build namespace defines the set of build targets
+type Build mg.Namespace
 
 const buildHome = "build"
 
@@ -53,6 +60,7 @@ var (
 
 // targets
 
+// Env prints the list of defined environment variables
 func (Info) Env() {
 	for _, k := range mgenv.Keys() {
 		v, _ := mgenv.Find(k)
@@ -60,14 +68,23 @@ func (Info) Env() {
 	}
 }
 
+// All runs all Prepare tasks
+func (Prepare) All() { mg.Deps(Prepare.Dirs) }
+
+// Dirs creates requires build directories for storing artifacts
+func (Prepare) Dirs() error { return mkdir("build") }
+
+// Lint runs golint
 func (Check) Lint() error {
 	return errors.New("TODO: implement me")
 }
 
-func (Prepare) Dirs() error {
-	return mkdir("build")
+// Clean removes build artifacts
+func Clean() error {
+	return sh.Rm(buildHome)
 }
 
+// Mage builds the magefile binary for reuse
 func (Build) Mage() error {
 	mg.Deps(Prepare.Dirs)
 
@@ -77,6 +94,7 @@ func (Build) Mage() error {
 	return sh.Run("mage", "-f", "-goos="+goos, "-goarch="+goarch, "-compile", out)
 }
 
+// Test builds the per package unit test executables.
 func (Build) Test() error {
 	mg.Deps(Prepare.Dirs)
 
@@ -93,37 +111,33 @@ func (Build) Test() error {
 	})
 }
 
+// Run package unit tests
 func Test() error {
 	mg.Deps(Prepare.Dirs)
 
 	return withList(gotool.ListProjectPackages, failFastEach, func(pkg string) error {
+		fmt.Println("Test:", pkg)
 		if b, err := gotool.HasTests(pkg); !b {
 			fmt.Printf("Skipping %v: No tests found\n", pkg)
 			return err
 		}
-
-		tst := gotool.Test
-		fmt.Println("Test:", pkg)
 
 		home := path.Join(buildHome, pkg)
 		if err := mkdir(home); err != nil {
 			return err
 		}
 
+		tst := gotool.Test
 		bin := path.Join(home, path.Base(pkg))
 		return tst(
 			tst.Use(useIf(bin, existsFile(bin) && envTestUseBin)),
-			tst.WithCoverage(path.Join(buildHome, pkg, "cover.out")),
+			tst.WithCoverage(path.Join(home, "cover.out")),
 			tst.Short(envTestShort),
 			tst.Out(bin),
 			tst.Package(pkg),
 			tst.Verbose(),
 		)
 	})
-}
-
-func Clean() error {
-	return sh.Rm(buildHome)
 }
 
 // helpers

--- a/magefile.go
+++ b/magefile.go
@@ -111,7 +111,7 @@ func (Build) Test() error {
 	})
 }
 
-// Run package unit tests
+// Test runs the unit tests.
 func Test() error {
 	mg.Deps(Prepare.Dirs)
 


### PR DESCRIPTION
We introduce support for testing other environments here. For now we only add ARM (32bit) support to our tests.

The Travis configs are updated to cross-compile and run the testsuite on ARM, via qemu. I've been able to reproduce the panic on atomic access, which has been fixed in #31 with these tests + some false assumption in an unit test has been fixed as well.

As the build and testing environment has become somewhat more complicated due to the need to cross compile and run/test via qemu, we introduce mage here. We hope for the full test suite and cross-combile/test support to be executable via Windows, Linux, and Darwin. We still target x86_64 dev environments, though.