### PR TITLE
Test and fix travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,6 +26,10 @@ jobs:
       env: TARGET=openbsd
       go: '$GO_CROSS_VERSION'
       script: eval $GO_CHECK_CROSS_SCRIPT
+      before_install:
+        - which travis_export_go
+        - file $(which travis_export_go)
+
     - name: XBuild NetBSD
       env: TARGET=netbsd
       go: '$GO_CROSS_VERSION'

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,16 +15,18 @@ matrix:
   - os: 'windows'
     go: 'tip'
 
+shared:
+  go_cross_version: &go_cross_version '1.11'
+
 env:
   global:
-    - GO_CROSS_VERSION='1.11'
     - GO_CHECK_CROSS_SCRIPT='GOOS=$TARGET go build ./...'
 jobs:
   include:
     # try to cross compile to untested OSes
     - name: XBuild OpenBSD
       env: TARGET=openbsd
-      go: '1.11'
+      go: *go_cross_version
       script: eval $GO_CHECK_CROSS_SCRIPT
       before_install:
         - which travis_export_go
@@ -32,11 +34,11 @@ jobs:
 
     - name: XBuild NetBSD
       env: TARGET=netbsd
-      go: '$GO_CROSS_VERSION'
+      go: *go_cross_version
       script: eval $GO_CHECK_CROSS_SCRIPT
     - name: XBuild FreeBSD
       env: TARGET=freebsd
-      go: '$GO_CROSS_VERSION'
+      go: *go_cross_version
       script: eval $GO_CHECK_CROSS_SCRIPT
 
     - name: 32Bit ARM go1.10

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ jobs:
     # try to cross compile to untested OSes
     - name: XBuild OpenBSD
       env: TARGET=openbsd
-      go: '$GO_CROSS_VERSION'
+      go: '1.11'
       script: eval $GO_CHECK_CROSS_SCRIPT
       before_install:
         - which travis_export_go

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,53 +17,48 @@ matrix:
 
 shared:
   go_cross_version: &go_cross_version '1.11'
+  bsd:
+    script: &go_bsd_script
+    - eval 'GOOS=$TARGET go build ./...'
+  arm:
+    before_install: &go_arm_before_install
+      - docker run --rm --privileged multiarch/qemu-user-static:register --reset
+      - |
+        go get -u -d github.com/magefile/mage
+        (cd $GOPATH/src/github.com/magefile/mage; go run bootstrap.go)
+    script: &go_arm_script
+      - mage -v test
 
-env:
-  global:
-    - GO_CHECK_CROSS_SCRIPT='GOOS=$TARGET go build ./...'
 jobs:
   include:
     # try to cross compile to untested OSes
     - name: XBuild OpenBSD
       env: TARGET=openbsd
       go: *go_cross_version
-      script: eval $GO_CHECK_CROSS_SCRIPT
-      before_install:
-        - which travis_export_go
-        - file $(which travis_export_go)
+      script: *go_bsd_script
 
     - name: XBuild NetBSD
       env: TARGET=netbsd
       go: *go_cross_version
-      script: eval $GO_CHECK_CROSS_SCRIPT
+      script: *go_bsd_script
     - name: XBuild FreeBSD
       env: TARGET=freebsd
       go: *go_cross_version
-      script: eval $GO_CHECK_CROSS_SCRIPT
+      script: *go_bsd_script
 
     - name: 32Bit ARM go1.10
       env: [BUILD_OS=linux, BUILD_ARCH=arm]
       go: '1.10'
       services: [docker]
-      before_install:
-        - docker run --rm --privileged multiarch/qemu-user-static:register --reset
-        - |
-          go get -u -d github.com/magefile/mage
-          (cd $GOPATH/src/github.com/magefile/mage; go run bootstrap.go)
-      script:
-        - mage -v test
+      before_install: *go_arm_before_install
+      script: *go_arm_script
 
     - name: 32Bit ARM go1.11
       env: [BUILD_OS=linux, BUILD_ARCH=arm]
       go: '1.11'
       services: [docker]
-      before_install:
-        - docker run --rm --privileged multiarch/qemu-user-static:register --reset
-        - |
-          go get -u -d github.com/magefile/mage
-          (cd $GOPATH/src/github.com/magefile/mage; go run bootstrap.go)
-      script:
-        - mage -v test
+      before_install: *go_arm_before_install
+      script: *go_arm_script
 
 # Check we're testing the correct commit (Snippet from: https://github.com/travis-ci/travis-ci/issues/7459#issuecomment-287040521)
 before_install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,15 +24,15 @@ jobs:
     # try to cross compile to untested OSes
     - name: XBuild OpenBSD
       env: TARGET=openbsd
-      go: $GO_CROSS_VERSION
+      go: '$GO_CROSS_VERSION'
       script: eval $GO_CHECK_CROSS_SCRIPT
     - name: XBuild NetBSD
       env: TARGET=netbsd
-      go: $GO_CROSS_VERSION
+      go: '$GO_CROSS_VERSION'
       script: eval $GO_CHECK_CROSS_SCRIPT
     - name: XBuild FreeBSD
       env: TARGET=freebsd
-      go: $GO_CROSS_VERSION
+      go: '$GO_CROSS_VERSION'
       script: eval $GO_CHECK_CROSS_SCRIPT
 
     - name: 32Bit ARM go1.10


### PR DESCRIPTION
Usage if environment variables seems to be more restricted due to travis recently escaping the string passed to `gimme`. Let's see if we can find a work-around without hardcoding the version in every place.

Checking the cross builds travis does take the version string from the `go` setting, but calls:

```
1. travis_export_go \$GO_VERSION <path-to-project>

...

2. setup environment variables

...

3. travis_setup_go -> fails due to `gimme not being able to find version \$GO_VERSION

...

```

Problem seems to be `travis_setup_go` not expanding the string (env variable), but passing the raw string as is.

Workaround: use YAML references.