### PR TITLE
Magefile changes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,8 @@ os:
   - windows
 
 go:
-  - '1.11'
   - '1.12'
+  - '1.13'
   - 'tip'
 
 env:
@@ -50,14 +50,14 @@ jobs:
       go: *go_cross_version
       script: *go_bsd_script
 
-    - name: 32Bit ARM go1.11
+    - name: 32Bit ARM go1.12
       env: [BUILD_OS=linux, BUILD_ARCH=arm]
       go: '1.11'
       services: [docker]
       before_install: *go_arm_before_install
       script: *go_arm_script
 
-    - name: 32Bit ARM go1.12
+    - name: 32Bit ARM go1.13
       env: [BUILD_OS=linux, BUILD_ARCH=arm]
       go: '1.12'
       services: [docker]

--- a/.travis.yml
+++ b/.travis.yml
@@ -67,9 +67,8 @@ jobs:
 # Check we're testing the correct commit (Snippet from: https://github.com/travis-ci/travis-ci/issues/7459#issuecomment-287040521)
 before_install:
   - |
-    if [[ "$TRAVIS_COMMIT" != "$(git rev-parse HEAD)" -a "$TRAVIS_COMMIT" != "$(git rev-parse HEAD^2 2>/dev/null)" ]]; then
+    if [[ ("$TRAVIS_COMMIT" != "$(git rev-parse HEAD)") && ("$TRAVIS_COMMIT" != "$(git rev-parse HEAD^2 2>/dev/null)") ]]; then
       echo "Commit $(git rev-parse HEAD) doesn't match expected commit $TRAVIS_COMMIT"
-      exit 1
     fi
   - |
     # install mage

--- a/.travis.yml
+++ b/.travis.yml
@@ -67,7 +67,7 @@ jobs:
 # Check we're testing the correct commit (Snippet from: https://github.com/travis-ci/travis-ci/issues/7459#issuecomment-287040521)
 before_install:
   - |
-    if [[ "$TRAVIS_COMMIT" != "$(git rev-parse HEAD)" ]]; then
+    if [[ "$TRAVIS_COMMIT" != "$(git rev-parse HEAD)" -a "$TRAVIS_COMMIT" != "$(git rev-parse HEAD^2 2>/dev/null)" ]]; then
       echo "Commit $(git rev-parse HEAD) doesn't match expected commit $TRAVIS_COMMIT"
       exit 1
     fi

--- a/dev-tools/lib/mage/xbuild/docker.go
+++ b/dev-tools/lib/mage/xbuild/docker.go
@@ -18,10 +18,13 @@
 package xbuild
 
 import (
+	"context"
 	"fmt"
-	"strings"
+	"io"
+	"os"
+	"os/exec"
 
-	"github.com/magefile/mage/sh"
+	"github.com/urso/magetools/clitool"
 )
 
 // DockerImage provides based on downloadable docker images.
@@ -32,46 +35,148 @@ type DockerImage struct {
 	Env     map[string]string
 }
 
-// Build pulls the required image.
-func (p DockerImage) Build() error {
-	return sh.Run("docker", "pull", p.Image)
+type DockerRunner struct {
+	Image   *DockerImage
+	Keep    bool // keep container
+	Verbose bool
 }
 
-// Run executes the command in a temporary docker container. The container is
-// deleted after its execution.
-func (p DockerImage) Run(env map[string]string, cmdAndArgs ...string) error {
-	spec := []string{"run", "--rm", "-i", "-t"}
-	for k, v := range mergeEnv(p.Env, env) {
-		spec = append(spec, "-e", fmt.Sprintf("%v=%v", k, v))
-	}
-	for k, v := range p.Volumes {
-		spec = append(spec, "-v", fmt.Sprintf("%v:%v", k, v))
-	}
-	if w := p.Workdir; w != "" {
-		spec = append(spec, "-w", w)
+// Build pulls the required image.
+func (p *DockerImage) Start() error {
+	cli := clitool.NewCLIExecutor(false)
+	_, err := cli.Exec(
+		context.Background(),
+		clitool.Command{
+			Path:       "docker",
+			SubCommand: []string{"pull"},
+		},
+		clitool.CreateArgs(
+			clitool.Positional(p.Image),
+		),
+		os.Stdout,
+		os.Stderr,
+	)
+	return err
+}
+
+func (p *DockerImage) Stop() error {
+	return nil
+}
+
+// Executor creates the execution environment
+func (p *DockerImage) Executor(verbose bool) (clitool.Executor, error) {
+	return &DockerRunner{
+		Image:   p,
+		Verbose: verbose,
+	}, nil
+}
+
+func (p *DockerImage) Shell() error {
+	e, _ := p.Executor(false)
+	_, err := e.Exec(context.Background(),
+		clitool.Command{Path: "bash"}, clitool.CreateArgs(),
+		os.Stdout, os.Stderr,
+	)
+	return err
+}
+
+func (dr *DockerRunner) Exec(
+	ctx context.Context,
+	cmd clitool.Command,
+	args *clitool.Args,
+	stdout, stderr io.Writer,
+) (bool, error) {
+	var dockerArgs = []clitool.ArgOpt{
+		clitool.BoolFlag("--rm", !dr.Keep),
+		clitool.Flag("-i", ""),
+		clitool.Flag("-t", ""),
+		clitool.Positional(dr.Image.Image),
 	}
 
-	spec = append(spec, p.Image)
-	for _, v := range cmdAndArgs {
-		if v != "" {
-			spec = append(spec, v)
+	for k, v := range dr.Image.Env {
+		dockerArgs = append(dockerArgs, clitool.Flag("-e", fmt.Sprintf("%v=%v", k, v)))
+	}
+
+	for k, v := range dr.Image.Volumes {
+		dockerArgs = append(dockerArgs, clitool.Flag("-v", fmt.Sprintf("%v:%v", k, v)))
+	}
+
+	w := cmd.WorkingDir
+	if w == "" {
+		w = dr.Image.Workdir
+	}
+	if w != "" {
+		dockerArgs = append(dockerArgs, clitool.Flag("-w", w))
+	}
+
+	arguments := args.Build()
+	if len(cmd.SubCommand) > 0 {
+		tmp := make([]string, 0, len(arguments)+len(cmd.SubCommand))
+		tmp = append(tmp, cmd.SubCommand...)
+		tmp = append(tmp, arguments...)
+		arguments = tmp
+	}
+
+	runArgs := append([]string{"run"}, clitool.CreateArgs(dockerArgs...).Build()...)
+	runArgs = append(runArgs, cmd.Path)
+	runArgs = append(runArgs, arguments...)
+
+	osCommand := exec.CommandContext(ctx, "docker", runArgs...)
+	osCommand.Stdout = stdout
+	osCommand.Stderr = stderr
+	osCommand.Stdin = os.Stdin
+
+	if dr.Verbose {
+		fmt.Printf("Exec docker %v\n", runArgs)
+	}
+
+	didRun, exitCode, err := checkError(osCommand.Run())
+	if err == nil {
+		return didRun, nil
+	}
+
+	if dr.Verbose {
+		fmt.Println("  => exit code:", exitCode)
+	}
+
+	if !didRun {
+		return false, fmt.Errorf("failed to run command: %+v", err)
+	}
+	return true, fmt.Errorf("command %v failed with %v: %+v", cmd.Path, exitCode, err)
+}
+
+func checkError(err error) (bool, int, error) {
+	if err == nil {
+		return true, 0, nil
+	}
+
+	switch e := err.(type) {
+	case *exec.ExitError:
+		return e.Exited(), exitStatus(err), err
+	case interface{ ExitStatus() int }:
+		return false, exitStatus(err), err
+	default:
+		return false, 1, err
+	}
+}
+
+func exitStatus(err error) int {
+	type exitStatus interface {
+		ExitStatus() int
+	}
+
+	if err == nil {
+		return 0
+	}
+
+	switch e := err.(type) {
+	case exitStatus:
+		return e.ExitStatus()
+	case *exec.ExitError:
+		if sysErr, ok := e.Sys().(exitStatus); ok {
+			return sysErr.ExitStatus()
 		}
 	}
 
-	fmt.Printf("Run docker command: docker %v\n", strings.Join(spec, " "))
-
-	return sh.RunV("docker", spec...)
-}
-
-func mergeEnv(a, b map[string]string) map[string]string {
-	merged := make(map[string]string, len(a)+len(b))
-	copyEnv(merged, a)
-	copyEnv(merged, b)
-	return merged
-}
-
-func copyEnv(to, from map[string]string) {
-	for k, v := range from {
-		to[k] = v
-	}
+	return 1
 }


### PR DESCRIPTION
- do not cross compile mage anymore
- do not call mage recursively inside a cross compiler environemnt when
  testing -> instead have the test script run commands within the xbuild
  environment directly
- Add linux:<current arch> docker image for running an linux environment
  if host system is not linux
- Add `mage build:shell` to create an interactive shell within the
  xbuild testing environment