### PR TITLE
Add AIX support

### DIFF
--- a/file_other.go
+++ b/file_other.go
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-// +build darwin dragonfly freebsd linux netbsd openbsd solaris
+// +build !windows
 
 package txfile
 

--- a/internal/vfs/osfs/mmap_other.go
+++ b/internal/vfs/osfs/mmap_other.go
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-// +build darwin dragonfly freebsd linux netbsd openbsd solaris
+// +build !windows
 
 package osfs
 

--- a/internal/vfs/osfs/sync_other.go
+++ b/internal/vfs/osfs/sync_other.go
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-// +build dragonfly freebsd netbsd openbsd solaris
+// +build !darwin,!linux,!windows
 
 package osfs
 


### PR DESCRIPTION
This PR won't work as is until https://github.com/gofrs/flock/pull/40 is merged. 
However, it's possible in go.mod to specify a local directory in GOPATH to replace a Go module. 
Therefore, once this PR has been merged, you can make it work on AIX by: 
 - cloning locally "github.com/gofrs/flock"
 - patch it with the previous PR https://github.com/gofrs/flock/pull/40. 
 - add at the end of go.mod `replace github.com/gofrs/flock => $path_to_your_local_gofrs`