### PR TITLE
Use core-windows-2019 instead of unmaintainted ci-windows-2019 image

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -16,7 +16,7 @@ steps:
         go_version:
           - "1.17"
         platform:
-          - "family/core-ubuntu-1804"
+          - "family/core-ubuntu-2204"
 
   - label: ":windows: Testing on Windows"
     key: windows-test

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -30,7 +30,7 @@ steps:
         go_version:
           - "1.17"
         platform:
-          - "family/ci-windows-2019"
+          - "family/core-windows-2019"
 
   - label: ":mac: Testing on MacOS"
     key: macos-test


### PR DESCRIPTION
The image family `ci-windows-2019` has been unmaintained for a while and has been replaced by `core-windows-2019`. This PR updates them to this instead.

Related to [incident 505.](https://elastic.slack.com/archives/C078RND5G5C)